### PR TITLE
Run deploy past the skipped fetch on push to main

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -120,7 +120,7 @@ jobs:
           FLAGS: --generated=${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
       - uses: actions/upload-pages-artifact@v3
   deploy-github:
-    if: github.ref == 'refs/heads/main'
+    if: ${{ !cancelled() && needs.render.result == 'success' && github.ref == 'refs/heads/main' }}
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}


### PR DESCRIPTION
## Problem

On push to `main`, `deploy-github` is **skipped** even though `render` succeeds — so the site stops deploying. Observed in [run 27010619934](https://github.com/jhrmnn/jhrmnn.github.io/actions/runs/27010619934): `build-image` ✅, `fetch` ⏭️ skipped, `render` ✅, `deploy-github` ⏭️ skipped.

## Cause

GitHub Actions propagates a skip down the `needs` chain (`fetch → render → deploy-github`) unless a job breaks the chain with a status-check function in its `if`.

- `fetch` is correctly skipped on push (it only runs on schedule/dispatch).
- `render` breaks the chain via `if: ${{ !cancelled() && ... }}`, so it runs.
- `deploy-github`'s condition was a plain `github.ref == 'refs/heads/main'` with no status function, so it kept the implicit `success()` and inherited the skip from the upstream skipped `fetch`.

## Fix

Gate deploy explicitly on `render`'s result with a status function — the same treatment `render` already uses:

```yaml
if: ${{ !cancelled() && needs.render.result == 'success' && github.ref == 'refs/heads/main' }}
```

Behavior:
- push to main: `fetch` skipped, `render` success → deploy **runs**
- push to other branch: ref ≠ main → skipped
- schedule/dispatch: `fetch` + `render` success → deploy runs
- `render` fails/skipped → deploy skipped

https://claude.ai/code/session_017rbzs8nvGLJdRLFpyE6QdN

---
_Generated by [Claude Code](https://claude.ai/code/session_017rbzs8nvGLJdRLFpyE6QdN)_