### PR TITLE
Add SessionStart hook to set up fetch/render environment

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+# SessionStart hook: prepare the environment so the `fetch` and `render`
+# CI steps (Makefile targets `fetch` and the default `cv`) can run locally.
+#
+# It installs the Python deps, the minimal LaTeX toolchain needed to build
+# the CV PDF, and downloads the web fonts. Mirrors the relevant pieces of
+# the Dockerfile and .github/workflows/build.yaml.
+set -euo pipefail
+
+# Only run in the Claude Code on the web remote environment.
+if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
+  exit 0
+fi
+
+cd "${CLAUDE_PROJECT_DIR:-.}"
+
+# 1. Python dependencies (used by both fetch.py and render.py).
+poetry install --only main
+
+# 2. Minimal LaTeX toolchain for `make` (cv.pdf via latexmk + xelatex).
+#    This is the curated set from the project Dockerfile; its dependency
+#    closure provides every package the CV template needs (fontspec, tikz,
+#    svg, titlesec, hanging, enumitem, everypage, ulem, geometry, ...).
+if ! command -v latexmk >/dev/null 2>&1 || ! command -v xelatex >/dev/null 2>&1; then
+  export DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC
+  sudo -E apt-get update -qq
+  sudo -E apt-get install -y --no-install-recommends \
+    latexmk \
+    texlive-base \
+    texlive-fonts-recommended \
+    texlive-plain-generic \
+    texlive-xetex
+fi
+
+# 3. Fonts for the CV PDF (same step as the render CI job / devcontainer).
+if [ -n "${FONTS_URL:-}" ] && [ ! -d fonts ]; then
+  wget -nv -O - "$FONTS_URL" | tar -xz
+fi
+
+echo "session-start hook: environment ready (fetch/render)"

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,14 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh"
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## What

Adds a SessionStart hook so the CI `fetch` and `render` Makefile targets can run in Claude Code on the web sessions.

- `.claude/hooks/session-start.sh` — installs Python deps (`poetry install --only main`), the minimal LaTeX toolchain needed to build the CV PDF, and downloads the web fonts. Web-only (`CLAUDE_CODE_REMOTE`), idempotent, non-interactive.
- `.claude/settings.json` — registers the hook on `SessionStart`.

## How this was derived

I ran the CI `fetch` and `render` steps directly in a fresh container and recorded what was needed:

| Need | Fresh env | Hook handles it |
|---|---|---|
| Python deps (`scholarly`, `bs4`, …) | missing | `poetry install --only main` |
| LaTeX (`latexmk`/`xelatex`) for `cv.pdf` | missing | minimal apt set |
| Web fonts | missing | `wget $FONTS_URL` |
| `make`, `poetry`, `wget` | present | — |

**Minimal LaTeX:** only the project's own curated set is needed — `latexmk texlive-base texlive-fonts-recommended texlive-plain-generic texlive-xetex`. Every package the CV template uses (fontspec, tikz, svg, titlesec, hanging, enumitem, everypage, ulem, geometry) resolves from that dependency closure, and there is no `\includesvg`, so inkscape is not required. `entr` (only used by `make dev`) is dropped.

## Validation

- ✅ Hook runs clean, idempotent, ~4.5s on a warm container.
- ✅ `render` builds `_site/index.html` and `_site/cv.txt` through the hook'd environment.
- ⚠️ `render → cv.pdf`: toolchain is correct (reaches xelatex; all packages load) but cannot complete here because the session's `FONTS_URL` archive is incomplete (missing Iosevka and several Baskerville-120 faces). External secret/config, not a setup gap.
- ⚠️ `fetch`: gets past all dependencies; fails only because `fetch.py` calls `api.github.com` unauthenticated and the shared egress IP is rate-limited (`403`). Publons/Crossref/Scholar worked. External rate limit, not a setup gap.

## Notes

- Hook runs **synchronously** (blocks startup until setup completes), guaranteeing tooling is ready before the session begins. Can be switched to async for faster startup.
- After merging to the default branch, all future web sessions will use it.

https://claude.ai/code/session_01BjcNEUSumjrqyMAwhq1LWv

---
_Generated by [Claude Code](https://claude.ai/code/session_01BjcNEUSumjrqyMAwhq1LWv)_