### PR TITLE
fetch: authenticate GitHub API calls with GITHUB_TOKEN

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -37,4 +37,16 @@ if [ -n "${FONTS_URL:-}" ] && [ ! -d fonts ]; then
   wget -nv -O - "$FONTS_URL" | tar -xz
 fi
 
+# 4. Expose the repo slug for the render path. `make` reuses the cached data
+#    artifact via reuse_data.py, which reads GITHUB_TOKEN (already provided)
+#    and GITHUB_REPOSITORY. The latter is set in CI but not in web sessions,
+#    so derive it from the git remote and persist it for the session.
+if [ -n "${CLAUDE_ENV_FILE:-}" ] && [ -z "${GITHUB_REPOSITORY:-}" ]; then
+  slug=$(git config --get remote.origin.url | tr ':' '/' \
+    | sed -E 's#\.git$##' | awk -F/ 'NF>=2{print $(NF-1)"/"$NF}')
+  if [ -n "$slug" ]; then
+    echo "export GITHUB_REPOSITORY=$slug" >> "$CLAUDE_ENV_FILE"
+  fi
+fi
+
 echo "session-start hook: environment ready (fetch/render)"

--- a/render.py
+++ b/render.py
@@ -232,9 +232,14 @@ def published_scholar_citations():
 def update_from_web(ctx, cache):  # noqa: C901
     def stars(item):
         if 'github' in item:
+            headers = {'accept': 'application/vnd.github.v3+json'}
+            # Authenticate when a token is available (CI and web sessions both
+            # export GITHUB_TOKEN); unauthenticated calls are rate-limited/403.
+            if token := os.environ.get('GITHUB_TOKEN'):
+                headers['authorization'] = f'Bearer {token}'
             info = cache.get(
                 f'https://api.github.com/repos/{item["github"]}',
-                headers={'accept': 'application/vnd.github.v3+json'},
+                headers=headers,
             )
             item.update(
                 {


### PR DESCRIPTION
## What

`fetch` crawls `api.github.com` for repo stars/descriptions. Those calls sent only an `accept` header, so they ran **unauthenticated** — GitHub rate-limits/blocks these and returns `403 Forbidden`, failing the whole fetch.

This attaches an `Authorization: Bearer $GITHUB_TOKEN` header when a token is present in the environment. Both CI (GitHub Actions) and Claude Code web sessions export `GITHUB_TOKEN`, so the crawl authenticates **automatically** with no manual setup. When no token is present, behavior is unchanged.

## Testing

- `make fetch` previously: `403` on all three GitHub repos.
- After the change: `libmbd/libmbd` and `jhrmnn/pyberny` return `200` and resolve.
- `make` (render) builds the full site end-to-end (`index.html`, `cv.pdf` via xelatex, `cv.txt`, …).
- `flake8 render.py` clean.

## Note (not addressed here)

One repo, `deepqmc/deepqmc`, still `403`s in the web session — but for a token-policy reason, not the code: the `deepqmc` org forbids fine-grained PATs with a lifetime > 366 days, and the session token is long-lived. GitHub Actions' built-in `GITHUB_TOKEN` is a short-lived installation token, so this won't trip the policy in CI.

https://claude.ai/code/session_01Y9vmtyQH7o5VRoUwLpg9cM

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y9vmtyQH7o5VRoUwLpg9cM)_