### PR TITLE
fetch: route Google Scholar through residential proxy

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -71,6 +71,7 @@ jobs:
         env:
           PUBLONS_TOKEN: ${{ secrets.PUBLONS_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SCHOLAR_PROXY: ${{ secrets.SCHOLAR_PROXY }}
       - uses: actions/upload-artifact@v4
         with:
           name: derived

--- a/render.py
+++ b/render.py
@@ -290,8 +290,17 @@ def update_from_web(ctx, cache):  # noqa: C901
 
     def scholar(ctx):
         def func():
+            # Route through a residential proxy when configured; Scholar blocks
+            # datacenter IPs but lets residential ones through. SCHOLAR_PROXY is
+            # a full proxy URL, e.g. http://user:pass@gw.dataimpulse.com:823.
+            proxies = None
+            if proxy := os.environ.get('SCHOLAR_PROXY'):
+                proxies = {'http': proxy, 'https': proxy}
             r = requests.get(
-                SCHOLAR_PROFILE_URL, headers=SCHOLAR_HEADERS, timeout=10
+                SCHOLAR_PROFILE_URL,
+                headers=SCHOLAR_HEADERS,
+                timeout=30,
+                proxies=proxies,
             )
             r.raise_for_status()
             return parse_scholar_profile_html(r.text)

--- a/render.py
+++ b/render.py
@@ -20,6 +20,10 @@ from bs4 import BeautifulSoup
 
 SMALL_CAPS = dict(zip('ᴍʏɴɢɪɴᴇ', 'myngine'))
 MAX_RETRIES = 3
+# Google Scholar blocks IPs with a bad reputation (429 "sorry" CAPTCHA). When a
+# residential proxy is configured each connection gets a fresh exit IP, so retry
+# a handful of times to land a clean one.
+SCHOLAR_PROXY_RETRIES = 5
 # Fetch the full publication list in a single request (the profile shows only
 # 20 rows by default); parse_scholar_profile_html reads the citation counts.
 SCHOLAR_PROFILE_URL = (
@@ -296,14 +300,26 @@ def update_from_web(ctx, cache):  # noqa: C901
             proxies = None
             if proxy := os.environ.get('SCHOLAR_PROXY'):
                 proxies = {'http': proxy, 'https': proxy}
-            r = requests.get(
-                SCHOLAR_PROFILE_URL,
-                headers=SCHOLAR_HEADERS,
-                timeout=30,
-                proxies=proxies,
-            )
-            r.raise_for_status()
-            return parse_scholar_profile_html(r.text)
+            # A fresh connection per attempt rotates the proxy's exit IP, so
+            # retrying sheds a flagged IP. No point retrying without a proxy:
+            # a datacenter IP stays blocked.
+            attempts = SCHOLAR_PROXY_RETRIES if proxies else 1
+            for attempt in range(attempts):
+                try:
+                    r = requests.get(
+                        SCHOLAR_PROFILE_URL,
+                        headers=SCHOLAR_HEADERS,
+                        timeout=30,
+                        proxies=proxies,
+                    )
+                    r.raise_for_status()
+                except requests.exceptions.RequestException as e:
+                    if attempt < attempts - 1:
+                        logging.info('Scholar fetch attempt %d failed: %r', attempt + 1, e)
+                        time.sleep(2)
+                        continue
+                    raise
+                return parse_scholar_profile_html(r.text)
 
         # Google Scholar blocks datacenter/CI IPs; on failure fall back to the
         # committed profile snapshot instead of failing the whole fetch.


### PR DESCRIPTION
## What

Google Scholar blocks datacenter/CI IPs, so the scheduled `fetch` job keeps falling back to the committed profile snapshot instead of pulling live citation counts. This wires a residential proxy (a DataImpulse plan) into the Scholar request.

## Changes

- `render.py`: the `scholar()` fetch now honours a `SCHOLAR_PROXY` env var. When set, the request goes through that proxy (`{'http': ..., 'https': ...}`). The proxy is applied **only** to the Scholar request — the GitHub/Crossref/Publons calls work fine from datacenter IPs, so this avoids burning residential proxy bandwidth on them. Timeout bumped 10s → 30s to tolerate the slower residential hop.
- `.github/workflows/build.yaml`: pass `SCHOLAR_PROXY` from repo secrets into the `fetch` job env.

When `SCHOLAR_PROXY` is unset (e.g. local runs), behaviour is unchanged — it falls back to the snapshot exactly as before.

## Required manual step

Add a repository (or environment) secret named **`SCHOLAR_PROXY`** with the full DataImpulse gateway URL, e.g.:

```
http://USERNAME:PASSWORD@gw.dataimpulse.com:823
```

(`gw.dataimpulse.com:823` is DataImpulse's rotating residential gateway; the username/password are the proxy credentials from the dashboard, not the account login. You can target a country by appending e.g. `__cr.us` to the username if needed.)

Once the secret is set, trigger the workflow (`workflow_dispatch`) to confirm Scholar resolves live instead of using the snapshot.

https://claude.ai/code/session_01CpQ9x3CVBjDPNVAKJ6vaqr

---
_Generated by [Claude Code](https://claude.ai/code/session_01CpQ9x3CVBjDPNVAKJ6vaqr)_