### PR TITLE
ci: guard fetched data against regressions

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -122,6 +122,16 @@ jobs:
           PUBLONS_TOKEN: ${{ secrets.PUBLONS_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SCHOLAR_PROXY: ${{ secrets.SCHOLAR_PROXY }}
+      - name: Check derived-data integrity
+        # Compares the fresh data against the last published artifact and fails
+        # if anything was removed/changed or a growth count dropped. Failing here
+        # aborts the job before the upload below, so the bad data isn't published
+        # (render needs fetch to succeed). A manual dispatch only logs the
+        # problems and carries on, so a known-good refresh can be forced through.
+        continue-on-error: ${{ github.event_name == 'workflow_dispatch' }}
+        run: poetry run make check
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions/upload-artifact@v4
         with:
           name: derived

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,11 @@ cv: $(addprefix $(OUTDIR)/,index.html cv.pdf cv.txt cv.yaml profile-pic.jpeg)
 fetch: | $(BLDDIR)
 	./fetch.py $(CTX) -o $(DERIVED)
 
+# Verify a freshly fetched dataset hasn't regressed against the last published
+# one (run after `make fetch`).
+check:
+	./check_derived.py $(DERIVED)
+
 # Otherwise reuse the most recent data artifact from a previous run.
 $(DERIVED): | $(BLDDIR)
 	./reuse_data.py -o $@

--- a/check_derived.py
+++ b/check_derived.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""Check that a freshly fetched derived dataset hasn't regressed.
+
+`fetch.py` rebuilds `build/derived.json` from live sources, which can degrade:
+an API hiccup, a soft block, a deleted Zotero item, or a recount can drop
+publications, rewrite bibliographic data, or report lower counts than what was
+last published. This compares the new dataset against the latest published
+`derived` artifact (the previous run's, since the fetch job runs this before
+uploading the new one) and exits non-zero if anything was removed, an identity
+field changed, or a count that should only grow went down. Running it at the end
+of the fetch job means a regression aborts before the artifact is uploaded.
+"""
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+
+import requests
+
+import reuse_data
+
+# Reference fields that identify a publication and must stay stable once
+# published. Volatile fields (cited_by is checked separately as a count; URL and
+# the GitHub-sourced software description/language change legitimately) are
+# intentionally excluded.
+REF_IDENTITY_FIELDS = ('title', 'author', 'issued', 'container-title')
+
+
+def load_baseline():
+    """Latest published derived data, or None when there's nothing to compare."""
+    try:
+        return json.loads(reuse_data.latest_derived_bytes())
+    except (requests.exceptions.RequestException, LookupError, KeyError, ValueError):
+        return None
+
+
+def scholar_value(derived):
+    return (
+        (derived.get('custom_data') or {}).get('scholar_citations', {}).get('value', {})
+    )
+
+
+def refs_by_id(derived):
+    return {r['id']: r for r in derived.get('references', [])}
+
+
+def check(old, new):  # noqa: C901
+    """Return a list of human-readable regression reasons (empty when clean)."""
+    problems = []
+
+    def removed(kind, old_keys, new_keys):
+        for k in old_keys:
+            if k not in new_keys:
+                problems.append(f'{kind} removed: {k}')
+
+    def decreased(kind, key, old_val, new_val):
+        # Only compare when both runs reported a number; a value going missing is
+        # treated as a transient gap (e.g. a Crossref 429), not a decrease.
+        if isinstance(old_val, int) and isinstance(new_val, int) and new_val < old_val:
+            problems.append(f'{kind} decreased: {key} {old_val} -> {new_val}')
+
+    # software: repos are append-only; stars only grow.
+    old_sw, new_sw = old.get('software', {}), new.get('software', {})
+    removed('software', old_sw, new_sw)
+    for repo, info in old_sw.items():
+        if repo in new_sw:
+            decreased('stars', repo, info.get('stars'), new_sw[repo].get('stars'))
+
+    # references: keyed by canonical DOI; append-only, stable identity, cited_by
+    # only grows.
+    old_refs, new_refs = refs_by_id(old), refs_by_id(new)
+    removed('reference', old_refs, new_refs)
+    for doi, ref in old_refs.items():
+        new_ref = new_refs.get(doi)
+        if new_ref is None:
+            continue
+        for field in REF_IDENTITY_FIELDS:
+            if ref.get(field) != new_ref.get(field):
+                problems.append(f'reference {doi} field changed: {field}')
+        decreased('cited_by', doi, ref.get('cited_by'), new_ref.get('cited_by'))
+
+    # n_reviews: monotonic.
+    decreased('n_reviews', 'n_reviews', old.get('n_reviews'), new.get('n_reviews'))
+
+    # Google Scholar citations: titles append-only, counts only grow.
+    old_sc, new_sc = scholar_value(old), scholar_value(new)
+    removed('scholar citation', old_sc, new_sc)
+    for title, count in old_sc.items():
+        if title in new_sc:
+            decreased('scholar citation', title, count, new_sc[title])
+
+    return problems
+
+
+def main(args):
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument('new', nargs='?', default='build/derived.json', type=Path)
+    a = p.parse_args(args)
+    new = json.loads(a.new.read_text())
+    old = load_baseline()
+    if old is None:
+        print('no baseline derived data to compare against; skipping check')
+        return
+    problems = check(old, new)
+    if not problems:
+        print('derived-data integrity OK')
+        return
+    print('derived-data integrity check failed:', file=sys.stderr)
+    for problem in problems:
+        print(f'  - {problem}', file=sys.stderr)
+    if summary := os.environ.get('GITHUB_STEP_SUMMARY'):
+        with open(summary, 'a') as f:
+            f.write('### Derived-data integrity check failed\n')
+            f.writelines(f'- {problem}\n' for problem in problems)
+    sys.exit(1)
+
+
+if __name__ == '__main__':
+    main(sys.argv[1:])


### PR DESCRIPTION
## Why

The `fetch` job rebuilds `build/derived.json` from live sources (Zotero, GitHub, Crossref, Publons, Google Scholar) and uploads it as the `derived` artifact, which is the single source of truth that gets rendered and published. Those sources can regress — an API hiccup, a soft block, a deleted Zotero item, or a recount can **drop** publications, **rewrite** bibliographic data, or report **lower** counts than what was last published. Until now nothing guarded against this, so a degraded fetch would silently overwrite the good artifact and get deployed.

## What

A new `check_derived.py`, run as a step at the end of the `fetch` job **before** the artifact upload. It compares the freshly fetched data against the last published `derived` artifact (which, because it runs before this run's upload, is the previous run's data — no run-exclusion needed) and fails if:

- **Removed** — a `software` repo, a `reference` (keyed by canonical DOI), or a Google Scholar title present in the baseline is gone.
- **Identity changed** — a still-present reference's stable fields (`title`, `author`, `issued`, `container-title`) differ. Volatile, source-controlled fields (GitHub description/language, URL) are intentionally ignored.
- **Count decreased** — a count that should only grow went down: GitHub `stars`, Crossref `cited_by`, Publons `n_reviews`, or Google Scholar citations. Counts are only compared when both runs reported a number, so a value going *missing* (e.g. a transient Crossref 429) is not treated as a decrease.

Every violation is logged with a reason and written to the job step summary.

## Gating behavior

- A failure **aborts the `fetch` job before the upload**, so the bad data is never uploaded; `render` (which requires `needs.fetch.result != 'failure'`) and therefore `deploy` are skipped — nothing is published.
- The single exception is a manual **`workflow_dispatch`**: via `continue-on-error: ${{ github.event_name == 'workflow_dispatch' }}` the check only logs the problems and the pipeline proceeds, so a known-good refresh can be forced through.
- When `fetch` is skipped entirely (data reuse), the check doesn't run and nothing changes.
- First run / no prior artifact ⇒ the check passes (nothing to compare).

No changes to `reuse_data.py` or the `deploy-github` job were needed.

## Files

- `check_derived.py` (new) — the comparison logic; reuses `reuse_data.latest_derived_bytes()`.
- `.github/workflows/build.yaml` — one integrity step in the `fetch` job.
- `Makefile` — `check` target (`./check_derived.py $(DERIVED)`) for local parity / used by the step.

## Verification

Logic exercised locally against crafted baseline-vs-new fixtures covering each violation kind (dropped DOI, lower stars, decreased `cited_by`, changed title, lower `n_reviews`, dropped/decreased Scholar count) plus a clean case, and the `main()` paths (no baseline ⇒ exit 0, clean ⇒ exit 0, broken ⇒ exit 1). `black --check` and `flake8` clean.

https://claude.ai/code/session_016DJ4p8ifDzU2WhRkxRwHG5

---
_Generated by [Claude Code](https://claude.ai/code/session_016DJ4p8ifDzU2WhRkxRwHG5)_