### PR TITLE
ci: add Cloudflare Pages per-PR previews

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -222,10 +222,31 @@ jobs:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           command: pages deploy _site --project-name=jhrmnngithubio --branch=${{ github.head_ref }}
-      - uses: marocchino/sticky-pull-request-comment@v2
+      # Post (or update in place) a single PR comment with the preview links,
+      # identified by an HTML-comment marker. Uses the official github-script
+      # action rather than a third-party one. URLs are passed via env, not
+      # string-interpolated into the script, to avoid any injection.
+      - uses: actions/github-script@v7
+        env:
+          ALIAS_URL: ${{ steps.deploy.outputs.pages-deployment-alias-url }}
+          DEPLOY_URL: ${{ steps.deploy.outputs.deployment-url }}
         with:
-          header: cloudflare-preview
-          message: |
-            Cloudflare Pages preview: ${{ steps.deploy.outputs.pages-deployment-alias-url }}
-
-            Latest commit deploy: ${{ steps.deploy.outputs.deployment-url }}
+          script: |
+            const marker = '<!-- cloudflare-preview -->';
+            const body = [
+              marker,
+              `Cloudflare Pages preview: ${process.env.ALIAS_URL}`,
+              '',
+              `Latest commit deploy: ${process.env.DEPLOY_URL}`,
+            ].join('\n');
+            const { owner, repo } = context.repo;
+            const issue_number = context.issue.number;
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner, repo, issue_number,
+            });
+            const existing = comments.find((c) => c.body.includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body });
+            } else {
+              await github.rest.issues.createComment({ owner, repo, issue_number, body });
+            }

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -12,6 +12,7 @@ permissions:
   id-token: write
   packages: write
   actions: read
+  pull-requests: write
 concurrency:
   group: pages
   cancel-in-progress: true
@@ -180,6 +181,13 @@ jobs:
         env:
           FLAGS: --generated=${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
       - uses: actions/upload-pages-artifact@v3
+      # Loose copy of the rendered site for the Cloudflare preview job;
+      # upload-pages-artifact above packs a Pages-only tarball that Wrangler
+      # can't consume.
+      - uses: actions/upload-artifact@v4
+        with:
+          name: site
+          path: _site
   deploy-github:
     if: ${{ !cancelled() && needs.render.result == 'success' && github.ref == 'refs/heads/main' }}
     environment:
@@ -190,3 +198,34 @@ jobs:
     steps:
       - id: deployment
         uses: actions/deploy-pages@v4
+  deploy-cloudflare:
+    # Per-PR preview on Cloudflare Pages. Production stays on GitHub Pages
+    # (deploy-github above); this only ever runs for pull requests, so every
+    # deploy lands on a non-production branch and Pages serves it as a preview.
+    # Requires a Direct Upload Pages project named below and the repo secrets
+    # CLOUDFLARE_API_TOKEN / CLOUDFLARE_ACCOUNT_ID. Secrets aren't exposed to
+    # PRs from forks, so previews only work for same-repo branches.
+    if: ${{ !cancelled() && needs.render.result == 'success' && github.event_name == 'pull_request' }}
+    runs-on: ubuntu-latest
+    needs: render
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: site
+          path: _site
+      - id: deploy
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: pages deploy _site --project-name=jhrmnn-cv --branch=${{ github.head_ref }}
+      - uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: cloudflare-preview
+          message: |
+            Cloudflare Pages preview: ${{ steps.deploy.outputs.pages-deployment-alias-url }}
+
+            Latest commit deploy: ${{ steps.deploy.outputs.deployment-url }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -221,7 +221,7 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          command: pages deploy _site --project-name=jhrmnn-cv --branch=${{ github.head_ref }}
+          command: pages deploy _site --project-name=jhrmnngithubio --branch=${{ github.head_ref }}
       - uses: marocchino/sticky-pull-request-comment@v2
         with:
           header: cloudflare-preview


### PR DESCRIPTION
## What

Adds per-PR preview deployments on **Cloudflare Pages**, while keeping production on **GitHub Pages** (`jhrmnn.github.io` unchanged).

## Why

The site builds via a custom Python/Make pipeline (Jinja2 + LaTeX/XeTeX) inside a Docker container, using private secrets (fonts, Scholar proxy, Publons) and a fetched data artifact. Cloudflare's git-integrated build can't run that, so the build stays in GitHub Actions and we only *upload* the prebuilt `_site/` to Cloudflare for previews.

## How

- `render` job additionally uploads the loose `_site/` as a `site` artifact (the existing `upload-pages-artifact` packs a Pages-only tarball Wrangler can't use).
- New `deploy-cloudflare` job runs **only on PRs**: downloads `site`, runs `wrangler pages deploy _site --branch=<head_ref>` (non-production branch ⇒ Pages serves it as a preview), and posts a sticky PR comment with the preview URL.
- `deploy-github` (production) is untouched.

## Required setup (outside the repo)

1. Create a **Direct Upload** Pages project named `jhrmnn-cv` with production branch `main` (never deployed to ⇒ all our deploys are previews). If you use a different project name, update `--project-name` in the workflow.
2. Repo secrets `CLOUDFLARE_API_TOKEN` + `CLOUDFLARE_ACCOUNT_ID` (done ✅).

Note: secrets aren't exposed to fork PRs, so previews only work for same-repo branches.

https://claude.ai/code/session_01WUWed2YcZKEQRJ8MXkNTUt

---
_Generated by [Claude Code](https://claude.ai/code/session_01WUWed2YcZKEQRJ8MXkNTUt)_