### PR TITLE
Add footer link to toggle the site's CSS on and off

### DIFF
--- a/templates/index.html.in
+++ b/templates/index.html.in
@@ -17,9 +17,16 @@
       article.removeChild(notice_star);
     }
   });
+  const styleEl = document.getElementById('site-styles');
+  const toggle = document.getElementById('style-toggle');
+  toggle.addEventListener('click', (e) => {
+    e.preventDefault();
+    styleEl.disabled = !styleEl.disabled;
+    toggle.textContent = styleEl.disabled ? 'enable styles' : 'disable styles';
+  });
 </script>
 
-<style>
+<style id="site-styles">
   {% include "templates/styles.css" %}
 </style>
 
@@ -267,7 +274,7 @@
   </section>
 </main>
 
-<footer>generated at {% if settings.generated %}<a href="{{ settings.generated }}">{{ settings.now }}</a>{% else %}{{ settings.now }}{% endif %}</footer>
+<footer>generated at {% if settings.generated %}<a href="{{ settings.generated }}">{{ settings.now }}</a>{% else %}{{ settings.now }}{% endif %} &middot; <a href="#" id="style-toggle">disable styles</a></footer>
 
 <script type="application/json" id="custom-data">
 {{ custom_data|tojson }}


### PR DESCRIPTION
## What

Adds a small **"disable styles"** link in the footer that uses JS to turn the site's CSS on and off. When off, the page falls back to raw unstyled HTML (browser defaults); clicking again restores the styling. The link label flips between "disable styles" / "enable styles".

State is **not** persisted — the page always loads styled.

## How

All changes are in `templates/index.html.in`:

1. Gave the inline `<style>` block an id: `<style id="site-styles">`.
2. Appended a toggle link to the `<footer>`: `· <a href="#" id="style-toggle">disable styles</a>`.
3. Wired up a click handler in the existing deferred `<script type="module">` that flips `styleEl.disabled` and updates the link label.

Since the stylesheet is inlined into a single `<style>` element, toggling its `disabled` property is the simplest reliable on/off switch — ~10 lines, no new files, no build-system changes.

## Verification

- `make _site/index.html` builds cleanly.
- Generated `_site/index.html` contains `id="site-styles"`, the footer `id="style-toggle"` link, and the toggle JS.
- In a browser: page loads styled → click "disable styles" → raw HTML, label reads "enable styles" → click again → styles return → reload loads styled again.

https://claude.ai/code/session_01XaECZxDnjYsASYhW7gDibp

---
_Generated by [Claude Code](https://claude.ai/code/session_01XaECZxDnjYsASYhW7gDibp)_