### PR TITLE
Improve semantics and no-CSS/no-JS correctness

### DIFF
--- a/templates/index.html.in
+++ b/templates/index.html.in
@@ -109,7 +109,7 @@
   <section>  
     <p class="p-note">{{ bio }}
     
-    <p id="profile-pic"><img class="u-photo" src="profile-pic.jpeg" alt="Jan Hermann">
+    <p id="profile-pic"><img class="u-photo" src="profile-pic.jpeg" alt="Jan Hermann" height="160">
     
     {{ dl_block(links, contact) }}
   </section>

--- a/templates/index.html.in
+++ b/templates/index.html.in
@@ -19,10 +19,10 @@
   });
   const styleEl = document.getElementById('site-styles');
   const toggle = document.getElementById('style-toggle');
-  toggle.addEventListener('click', (e) => {
-    e.preventDefault();
+  toggle.addEventListener('click', () => {
     styleEl.disabled = !styleEl.disabled;
     toggle.textContent = styleEl.disabled ? 'enable styles' : 'disable styles';
+    toggle.setAttribute('aria-pressed', String(styleEl.disabled));
   });
 </script>
 
@@ -91,7 +91,7 @@
   </dl>
 {% endmacro %}
 
-<nav>
+<nav aria-label="Sections">
   <ul>
     <li><a href="#Publications">Publications</a>
     <li><a href="#Software">Software</a>
@@ -109,7 +109,7 @@
   <section>  
     <p class="p-note">{{ bio }}
     
-    <p id="profile-pic"><img class="u-photo" src="profile-pic.jpeg">
+    <p id="profile-pic"><img class="u-photo" src="profile-pic.jpeg" alt="Jan Hermann">
     
     {{ dl_block(links, contact) }}
   </section>
@@ -139,7 +139,7 @@
         <li>
             <strong><a href="{{ item.url }}">{{ item.name }}</a></strong>&nbsp;&middot;
             {{ item.role }}{% if item.stars %}&nbsp;&middot; <em>{{ item.stars }} {% include "assets/github-star.svg" %}</em>{% endif %}
-            {% if item.description %}</br>{{ item.description}}{% endif %}
+            {% if item.description %}<br>{{ item.description}}{% endif %}
       {% endfor %}
     </ul>
   </section>
@@ -160,7 +160,7 @@
     {{ talk_block(presentations.seminars, "talks") }}
   </section>
 
-  <section id="CV">
+  <section id="CV" aria-label="CV">
     <h2>Employment</h2>
     <table class="cvblock">
       {% for item in employment %}
@@ -274,7 +274,7 @@
   </section>
 </main>
 
-<footer>generated at {% if settings.generated %}<a href="{{ settings.generated }}">{{ settings.now }}</a>{% else %}{{ settings.now }}{% endif %} &middot; <a href="#" id="style-toggle">disable styles</a></footer>
+<footer>generated at {% if settings.generated %}<a href="{{ settings.generated }}">{{ settings.now }}</a>{% else %}{{ settings.now }}{% endif %} &middot; <button type="button" id="style-toggle" aria-pressed="false">disable styles</button></footer>
 
 <script type="application/json" id="custom-data">
 {{ custom_data|tojson }}

--- a/templates/styles.css
+++ b/templates/styles.css
@@ -82,6 +82,20 @@ footer {
     margin-top: 2em;
 }
 
+#style-toggle {
+    font: inherit;
+    color: #347AB7;
+    background: none;
+    border: none;
+    padding: 0;
+    cursor: pointer;
+}
+
+#style-toggle:hover {
+    color: #2D6A9F;
+    text-decoration: underline;
+}
+
 .pub {
     font-size: 0.95em;
 }
@@ -218,6 +232,14 @@ tr.heading:not(:first-child) td {
     }
 
     a:hover {
+        color: #74a9d8;
+    }
+
+    #style-toggle {
+        color: #609dd2;
+    }
+
+    #style-toggle:hover {
         color: #74a9d8;
     }
 }


### PR DESCRIPTION
Small, focused improvements to how the page behaves with CSS and/or JS disabled, and to its semantics.

## Changes

- **`alt` on the profile image** — previously had none, so it was an unlabeled image for screen readers and when images/CSS are off.
- **`</br>` → `<br>`** — `</br>` is invalid markup (browsers tolerate it, but it shouldn't be in output).
- **Style toggle is now a `<button>`** instead of `<a href="#">` — it's an in-page action, not navigation. As a link it scrolled to the top when JS was off; as a `<button>` it does nothing without JS, which is the honest behavior. Added `aria-pressed` that tracks state, and dropped the now-unneeded `preventDefault`. A small CSS rule keeps it looking like the surrounding footer link (light + dark mode).
- **`aria-label` on the section `<nav>`** and **`aria-label="CV"` on the CV section** — names the otherwise-unlabeled landmarks (the CV section's first heading is "Employment", so the nav "CV" target had no matching accessible name).

## Considered but deliberately not done

- **Restructuring the CV heading hierarchy** (wrapping Employment/Education/etc. under a "CV" heading). This turned out to be an information-architecture preference rather than a correctness bug — the HTML5 document-outline algorithm was never implemented by browsers or assistive tech, which read a flat list of heading levels. The flat structure is perfectly navigable, so this was left as-is and the landmark just got a name instead.
- **Converting the publications/talks `<table>`s to lists** — they render fine and readably without CSS, so not worth the churn/risk.

https://claude.ai/code/session_01CcvcdCKkpqhVEBnCLsutRS

---
_Generated by [Claude Code](https://claude.ai/code/session_01CcvcdCKkpqhVEBnCLsutRS)_