### PR TITLE
Persist CSS toggle across reloads; scope CI concurrency to the ref

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -14,7 +14,11 @@ permissions:
   actions: read
   pull-requests: write
 concurrency:
-  group: pages
+  # Scope to the triggering ref so PR runs and main runs don't cancel each
+  # other; a static group would put every run in one bucket and, with
+  # cancel-in-progress, let any new run preempt an unrelated one. Same-ref
+  # superseding (e.g. a new push to a branch) is still cancelled.
+  group: pages-${{ github.ref }}
   cancel-in-progress: true
 jobs:
   build-image:

--- a/templates/index.html.in
+++ b/templates/index.html.in
@@ -19,16 +19,25 @@
   });
   const styleEl = document.getElementById('site-styles');
   const toggle = document.getElementById('style-toggle');
-  toggle.addEventListener('click', () => {
-    styleEl.disabled = !styleEl.disabled;
+  const syncToggle = () => {
     toggle.textContent = styleEl.disabled ? 'enable styles' : 'disable styles';
     toggle.setAttribute('aria-pressed', String(styleEl.disabled));
+  };
+  syncToggle();
+  toggle.addEventListener('click', () => {
+    styleEl.disabled = !styleEl.disabled;
+    syncToggle();
+    try { localStorage.setItem('styles', styleEl.disabled ? 'off' : 'on'); } catch (e) {}
   });
 </script>
 
 <style id="site-styles">
   {% include "templates/styles.css" %}
 </style>
+<script>
+  // Apply the persisted toggle state before paint to avoid a flash of styles.
+  try { document.getElementById('site-styles').disabled = localStorage.getItem('styles') === 'off'; } catch (e) {}
+</script>
 
 <link rel="icon" type="image/png" href="data:image/png;base64,{% include "favicon.png.b64" %}">
 <link rel="canonical" href="https://jan.hermann.name">


### PR DESCRIPTION
## What

Two changes:

### 1. Persist the CSS toggle across reloads (follow-up to #29)
The footer CSS on/off toggle now remembers its state. Previously the page always loaded styled.

- **Persist on click** — the handler writes the choice to `localStorage` (`'styles'` → `'on'`/`'off'`).
- **Restore before paint** — a small synchronous `<script>` immediately after the `<style id="site-styles">` block reads `localStorage` and sets `disabled` before paint, so reloading with styles off does **not** flash styled content first.
- **Label init** — the deferred module script initialises the link label to match the restored state.
- Both `localStorage` accesses are wrapped in `try/catch` for sandboxed/privacy contexts.

### 2. Scope CI concurrency to the ref
The `build.yaml` workflow used a static concurrency group (`pages`) with `cancel-in-progress: true`, so every run across the repo shared one bucket and any newly started run preempted whatever was already running — e.g. a push to `main` cancelling an in-flight PR build (this is what cancelled the first run of this PR). Changed the group to `pages-${{ github.ref }}` so only same-ref runs supersede one another. Pages deploys (main only) still serialise under a single ref group.

## Verification

- `make _site/index.html` builds cleanly; rendered output contains the early restore script, the `setItem` on toggle, and the label init.
- Workflow YAML validated.
- In a browser: disable styles → reload → page stays unstyled, link reads "enable styles", no flash; enable → reload → styled again.

https://claude.ai/code/session_01XaECZxDnjYsASYhW7gDibp