### PR TITLE
Cross-check Zotero/ORCID/Scholar on pushes to main

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -98,14 +98,11 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build-image, changes]
     # !cancelled() so a skipped changes job (schedule/dispatch) doesn't skip fetch.
-    # Pushes to main always fetch (even when no fetch input changed) so the
-    # Zotero/ORCID/Scholar cross-check below runs on every production deploy.
     if: >-
       !cancelled() &&
       needs.build-image.result == 'success' &&
       (github.event_name == 'schedule' ||
       github.event_name == 'workflow_dispatch' ||
-      (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
       needs.changes.outputs.fetch == 'true')
     container:
       image: ghcr.io/${{ github.repository }}:${{ needs.build-image.outputs.docker-tag }}
@@ -142,11 +139,17 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Cross-check Zotero, ORCID and Google Scholar
         # Gate production deploys on the three publication sources agreeing.
-        # Only on pushes to main: PRs and the daily refresh shouldn't be blocked
-        # by a mismatch that's the author's to reconcile (e.g. a paper not yet
-        # added to ORCID). Failing here aborts before the upload below, so render
-        # and the Pages deploy are skipped and inconsistent data isn't published.
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        # Runs whenever fetch produces data that will be published: the daily
+        # schedule and manual dispatch (both deploy to main), plus a push to main
+        # that changed fetch inputs (fetch already runs, so no extra crawl). Not
+        # on PRs, which don't deploy and shouldn't be blocked by a mismatch
+        # that's the author's to reconcile (e.g. a paper not yet added to ORCID).
+        # Failing here aborts before the upload below, so render and the Pages
+        # deploy are skipped and inconsistent data isn't published.
+        if: >-
+          github.event_name == 'schedule' ||
+          github.event_name == 'workflow_dispatch' ||
+          (github.event_name == 'push' && github.ref == 'refs/heads/main')
         run: poetry run make check-sources
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -140,16 +140,17 @@ jobs:
       - name: Cross-check Zotero, ORCID and Google Scholar
         # Gate production deploys on the three publication sources agreeing.
         # Runs whenever fetch produces data that will be published: the daily
-        # schedule and manual dispatch (both deploy to main), plus a push to main
-        # that changed fetch inputs (fetch already runs, so no extra crawl). Not
-        # on PRs, which don't deploy and shouldn't be blocked by a mismatch
+        # schedule and manual dispatch (both deploy to main), plus a push that
+        # changed fetch inputs (fetch already runs, so no extra crawl). The
+        # workflow's push trigger is main-only, so checking the event is enough.
+        # Not on PRs, which don't deploy and shouldn't be blocked by a mismatch
         # that's the author's to reconcile (e.g. a paper not yet added to ORCID).
         # Failing here aborts before the upload below, so render and the Pages
         # deploy are skipped and inconsistent data isn't published.
         if: >-
           github.event_name == 'schedule' ||
           github.event_name == 'workflow_dispatch' ||
-          (github.event_name == 'push' && github.ref == 'refs/heads/main')
+          github.event_name == 'push'
         run: poetry run make check-sources
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -98,11 +98,14 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build-image, changes]
     # !cancelled() so a skipped changes job (schedule/dispatch) doesn't skip fetch.
+    # Pushes to main always fetch (even when no fetch input changed) so the
+    # Zotero/ORCID/Scholar cross-check below runs on every production deploy.
     if: >-
       !cancelled() &&
       needs.build-image.result == 'success' &&
       (github.event_name == 'schedule' ||
       github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
       needs.changes.outputs.fetch == 'true')
     container:
       image: ghcr.io/${{ github.repository }}:${{ needs.build-image.outputs.docker-tag }}
@@ -137,6 +140,14 @@ jobs:
         run: poetry run make check
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Cross-check Zotero, ORCID and Google Scholar
+        # Gate production deploys on the three publication sources agreeing.
+        # Only on pushes to main: PRs and the daily refresh shouldn't be blocked
+        # by a mismatch that's the author's to reconcile (e.g. a paper not yet
+        # added to ORCID). Failing here aborts before the upload below, so render
+        # and the Pages deploy are skipped and inconsistent data isn't published.
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        run: poetry run make check-sources
       - uses: actions/upload-artifact@v4
         with:
           name: derived

--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,11 @@ fetch: | $(BLDDIR)
 check:
 	./check_derived.py $(DERIVED)
 
+# Cross-check that Zotero, ORCID and Google Scholar agree on the publication
+# list and its substance (run after `make fetch`, gated to pushes to main).
+check-sources:
+	./check_sources.py $(DERIVED)
+
 # Otherwise reuse the most recent data artifact from a previous run.
 $(DERIVED): | $(BLDDIR)
 	./reuse_data.py -o $@

--- a/check_sources.py
+++ b/check_sources.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+"""Cross-check that the three publication sources agree.
+
+The site's reference list comes from the Zotero "My Publications" library;
+ORCID and Google Scholar are independent records of the same publications. This
+reads a freshly fetched `build/derived.json` and verifies that all three list
+the same papers and that, for each paper, ORCID's substance matches Zotero's.
+
+The only differences tolerated are accents, letter case, and unicode-vs-ascii
+spelling of the same character (see `common.fold_text`); anything else -- a
+paper present in one source but not another, a preprint-vs-published DOI/type
+mismatch, a differing year -- is a regression. Run at the end of the fetch job
+on pushes to main (see the workflow), a non-zero exit aborts before the artifact
+is uploaded, so the site never deploys from inconsistent sources.
+
+Field coverage differs by source: Zotero (CSL-JSON) is richest; ORCID exposes
+title, type, year and DOI per work; Google Scholar's profile listing only
+exposes titles reliably. So Scholar is checked for presence only, while the
+field-level substance check (DOI, preprint-vs-published status, year) is done
+against ORCID. ORCID does not carry volume/page, so those are not cross-checked.
+"""
+
+import argparse
+import json
+import os
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+from common import title_key
+
+# CSL (Zotero) and ORCID name publication types differently; map both onto a
+# common vocabulary so e.g. a Zotero preprint and an ORCID preprint compare
+# equal while a preprint vs a published article does not. Unknown types fall
+# through to their raw string (still compared, just not unified).
+ZOTERO_STATUS = {
+    'article': 'preprint',
+    'article-journal': 'journal',
+    'chapter': 'chapter',
+    'thesis': 'thesis',
+}
+ORCID_STATUS = {
+    'preprint': 'preprint',
+    'journal-article': 'journal',
+    'book-chapter': 'chapter',
+    'dissertation-thesis': 'thesis',
+    'dissertation': 'thesis',
+}
+
+
+def ref_year(ref):
+    issued = ref.get('issued') or {}
+    parts = issued.get('date-parts') or [[]]
+    return str(parts[0][0]) if parts and parts[0] else None
+
+
+def scholar_titles(derived):
+    value = (
+        (derived.get('custom_data') or {}).get('scholar_citations', {}).get('value', {})
+    )
+    return list(value)
+
+
+def check(refs, orcid, scholar):  # noqa: C901
+    """Return a list of human-readable disagreement reasons (empty when clean)."""
+    problems = []
+
+    # Index ORCID works both ways: by title (to pair) and by DOI (to collapse
+    # ORCID's per-version duplicates onto the Zotero paper they belong to).
+    o_by_title = defaultdict(list)
+    o_by_doi = defaultdict(list)
+    for work in orcid:
+        o_by_title[title_key(work['title'])].append(work)
+        for doi in work.get('dois') or []:
+            o_by_doi[doi].append(work)
+
+    z_titles = set()
+    z_dois = set()
+    if not orcid:
+        problems.append('no ORCID works to cross-check against')
+    for ref in refs:
+        z_titles.add(title_key(ref['title']))
+        doi = ref.get('id')  # canonical DOI: the same join key fetch.py builds
+        if doi:
+            z_dois.add(doi)
+        if not orcid:
+            continue
+        # Pair on title, falling back to a shared DOI when the titles diverge
+        # by more than the tolerated folds.
+        cands = o_by_title.get(title_key(ref['title'])) or (o_by_doi.get(doi) or [])
+        if not cands:
+            problems.append(f'absent from ORCID: {ref["title"]!r}')
+            continue
+        same_doi = [c for c in cands if doi in (c.get('dois') or [])]
+        if not same_doi:
+            orcid_dois = sorted({d for c in cands for d in c.get('dois') or []})
+            problems.append(
+                f'DOI mismatch (preprint vs published?): {ref["title"]!r} '
+                f'Zotero {doi} vs ORCID {orcid_dois}'
+            )
+            continue
+        work = same_doi[0]
+        z_status = ZOTERO_STATUS.get(ref.get('type'), ref.get('type'))
+        o_status = ORCID_STATUS.get(work.get('type'), work.get('type'))
+        if z_status != o_status:
+            problems.append(
+                f'status differs: {ref["title"]!r} '
+                f'Zotero {z_status} vs ORCID {o_status}'
+            )
+        z_year, o_year = ref_year(ref), work.get('year')
+        if z_year and o_year and z_year != o_year:
+            problems.append(
+                f'year differs: {ref["title"]!r} Zotero {z_year} vs ORCID {o_year}'
+            )
+
+    # ORCID works that match no Zotero paper -- by title or by a shared DOI (the
+    # latter skips ORCID's own duplicate records of papers Zotero does list).
+    for work in orcid:
+        if title_key(work['title']) not in z_titles and not (
+            set(work.get('dois') or []) & z_dois
+        ):
+            problems.append(f'in ORCID but not Zotero: {work["title"]!r}')
+
+    # Google Scholar auto-indexes extra items (talks, duplicates) we can't
+    # curate away, so only require it to cover the Zotero papers, and skip the
+    # check entirely when Scholar data is missing (a soft block) rather than
+    # flagging every paper.
+    if scholar:
+        s_titles = {title_key(t) for t in scholar}
+        for ref in refs:
+            if title_key(ref['title']) not in s_titles:
+                problems.append(f'absent from Google Scholar: {ref["title"]!r}')
+
+    return problems
+
+
+def main(args):
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument('derived', nargs='?', default='build/derived.json', type=Path)
+    a = p.parse_args(args)
+    derived = json.loads(a.derived.read_text())
+    problems = check(
+        derived.get('references', []),
+        derived.get('orcid', []),
+        scholar_titles(derived),
+    )
+    if not problems:
+        print('publication sources agree')
+        return
+    print('publication sources disagree:', file=sys.stderr)
+    for problem in problems:
+        print(f'  - {problem}', file=sys.stderr)
+    if summary := os.environ.get('GITHUB_STEP_SUMMARY'):
+        with open(summary, 'a') as f:
+            f.write('### Publication sources disagree\n')
+            f.writelines(f'- {problem}\n' for problem in problems)
+    sys.exit(1)
+
+
+if __name__ == '__main__':
+    main(sys.argv[1:])

--- a/common.py
+++ b/common.py
@@ -6,6 +6,7 @@ These live here so `fetch.py` and `render.py` stay independent of each other
 need.
 """
 import re
+import unicodedata
 
 import yaml
 
@@ -16,6 +17,31 @@ def reduce_sc(x):
     for f, t in SMALL_CAPS.items():
         x = x.replace(f, t)
     return x
+
+
+def fold_text(s):
+    """Fold away the only differences treated as insignificant when comparing
+    bibliographic data across sources: small-caps unicode (``PʏSCF`` ->
+    ``pyscf``), accents, other unicode/ascii spellings of the same character,
+    and letter case. Everything else is preserved so a real difference (a
+    different word, a different number) still shows up.
+    """
+    s = reduce_sc(s or '')
+    s = unicodedata.normalize('NFKD', s)
+    s = ''.join(c for c in s if not unicodedata.combining(c))
+    return s.casefold()
+
+
+def title_key(s):
+    """Loose key for deciding whether two records describe the same work.
+
+    ``fold_text`` plus dropping HTML markup and collapsing every run of
+    non-alphanumerics to a single space, so punctuation, spacing or markup
+    differences never split a pair. Used only to *pair* records; their substance
+    is then compared field by field.
+    """
+    s = re.sub(r'<[^>]+>', '', fold_text(s))
+    return ' '.join(re.sub(r'[^a-z0-9]+', ' ', s).split())
 
 
 def strip_html(str):

--- a/fetch.py
+++ b/fetch.py
@@ -41,6 +41,13 @@ ZOTERO_REFS_URL = (
     'https://api.zotero.org/users/1562978/publications/items?'
     + urlencode({'format': 'csljson', 'itemType': '-attachment || note', 'limit': 100})
 )
+# Public ORCID record of the same publications, used by check_sources.py to
+# cross-check the Zotero list. The summary works endpoint gives title, type,
+# year and DOI per work -- enough to catch a paper that's missing from, or
+# recorded differently than, Zotero (e.g. preprint vs published).
+ORCID_ID = '0000-0002-2779-0749'
+ORCID_WORKS_URL = f'https://pub.orcid.org/v3.0/{ORCID_ID}/works'
+ORCID_HEADERS = {'Accept': 'application/json'}
 
 
 class Cache:
@@ -176,6 +183,42 @@ def fetch_references(cache):
     return refs
 
 
+def fetch_orcid(cache):
+    """Flat list of the public ORCID works, one record per work summary.
+
+    ORCID lists each work's versions (preprint, published, ...) under the same
+    title, so duplicates are expected; check_sources.py collapses them by DOI.
+    DOIs are canonicalised to the same `10.prefix/suffix` join key Zotero uses.
+    """
+    data = cache.get(ORCID_WORKS_URL, headers=ORCID_HEADERS)
+    works = []
+    for group in data.get('group', []):
+        for summary in group.get('work-summary', []):
+            title = (((summary.get('title') or {}).get('title')) or {}).get('value')
+            if not title:
+                continue
+            dois = sorted(
+                {
+                    canonical_doi(eid['external-id-value'], cache)
+                    for eid in (summary.get('external-ids') or {}).get(
+                        'external-id', []
+                    )
+                    if eid.get('external-id-type') == 'doi'
+                }
+            )
+            pubdate = summary.get('publication-date') or {}
+            year = ((pubdate.get('year') or {}).get('value')) if pubdate else None
+            works.append(
+                {
+                    'title': title,
+                    'dois': dois,
+                    'type': summary.get('type'),
+                    'year': str(year) if year else None,
+                }
+            )
+    return works
+
+
 def update_from_web(ctx, cache):  # noqa: C901
     def stars(item):
         if 'github' in item:
@@ -272,6 +315,14 @@ def update_from_web(ctx, cache):  # noqa: C901
             logging.warning('Could not fetch Google Scholar profile: %r', e)
 
     ctx['references'] = fetch_references(cache)
+    # ORCID only gates the push-to-main cross-check; a transient outage
+    # shouldn't fail unrelated fetches, so degrade to an empty list (which
+    # check_sources.py reports as "no ORCID data" on main).
+    try:
+        ctx['orcid'] = fetch_orcid(cache)
+    except requests.exceptions.RequestException as e:
+        logging.warning('Could not fetch ORCID works: %r', e)
+        ctx['orcid'] = []
     with concurrent.futures.ThreadPoolExecutor(max_workers=4) as pool:
         futures = [
             pool.submit(func, x)
@@ -336,6 +387,7 @@ def extract_derived(ctx):
             if 'github' in item and 'stars' in item
         },
         'references': ctx['references'],
+        'orcid': ctx.get('orcid', []),
         'n_reviews': ctx.get('_n_reviews'),
         'custom_data': ctx['custom_data'],
     }


### PR DESCRIPTION
## What

Adds a CI gate that verifies the three publication sources agree before a production deploy. The site's reference list comes from **Zotero**; **ORCID** and **Google Scholar** independently record the same papers, and they can silently drift — a paper added to one but not another, or a preprint in one source vs the published version in another. When fetch produces data that will be published, a mismatch now aborts the fetch job before the artifact is uploaded, so render/deploy are skipped and the site never publishes from inconsistent sources (the same way a failed fetch already prevents publishing).

## Normalizing the three sources for a reliable cross-check

I probed the live sources first. The key finding: **DOI cannot be the join key** — the same paper carries *different* DOIs across sources (Zotero tracks the arXiv/chemrxiv **preprint** DOI, ORCID the **published-journal** DOI). So records are paired by a normalized **title** instead:

- `common.title_key` folds away the only differences treated as insignificant: small-caps unicode (`PʏSCF`→`pyscf`, `QCEɴɢɪɴᴇ`→`qcengine`), accents, letter case, and unicode↔ascii spelling — then strips HTML markup and collapses punctuation/spacing. This is what makes the cross-check reliable; without the small-caps fold alone, two real papers were spuriously flagged.
- Paired records are then compared **field by field against ORCID** (DOI, preprint-vs-published status, year), tolerating only the folded differences — anything else is a failure.
- ORCID's per-version duplicate records (it lists preprint + published under one title) are collapsed onto the matching Zotero paper by **shared DOI**, so they aren't reported as spurious extras.
- **Scholar** auto-indexes extra items (talks, duplicates) that can't be curated away and its profile listing only exposes titles reliably, so it's checked for **presence only** (every Zotero paper must appear; extras tolerated; skipped entirely on a soft block rather than flagging everything).

> Note on field coverage: ORCID exposes title/type/year/DOI but **not volume/page**, and Scholar's per-paper detail pages are blocked, so volume/page aren't cross-checkable across these three sources. The DOI + preprint-vs-published-status + year checks already catch the "one preprint, the other published" case.

## Changes

- **`common.py`** — `fold_text` and `title_key` normalization helpers, shared by fetch and the check.
- **`fetch.py`** — fetches the public ORCID works into the derived artifact (non-fatal on outage; canonicalizes DOIs to the same join key Zotero uses).
- **`check_sources.py`** (new) — `make check-sources`; runs the cross-check over `build/derived.json` and exits non-zero on disagreement, mirroring `check_derived.py`'s structure (stderr + `GITHUB_STEP_SUMMARY`).
- **`build.yaml`** — runs the check in the fetch job, after the integrity check and before the artifact upload. The fetch job keeps its original trigger (schedule, manual dispatch, or a push/PR touching fetch inputs — **no forced fetch on every main push**). The cross-check runs whenever fetch produces publishable data: `schedule` and `workflow_dispatch` (both deploy to main) plus a push to main that changed fetch inputs. Not on PRs, which don't deploy.

## Gating, in practice

- A plain content push to `main` (no fetch-input change) skips the fetch job entirely and still deploys from the last good artifact — only **data-refreshing** runs are gated.
- The daily schedule (and any manual dispatch) runs the cross-check before publishing.

## This intentionally fails today

Per the request, the gate fails on the current real drift rather than allowlisting it. The next scheduled/dispatched run currently reports:

```
- DOI mismatch (preprint vs published?): 'Accurate Chemistry Collection: ...'
    Zotero 10.48550/arxiv.2506.14492 vs ORCID ['10.1038/s41597-026-07200-8']
- absent from ORCID: 'An ab initio foundation model of wavefunctions ...'
- absent from ORCID: 'Roadmap on Advancements of the FHI-aims Software Package'
- absent from ORCID: 'Nonlocal correlation in density functional theory'
- year differs: 'Tuning intermolecular interactions with nanostructured environments'
    Zotero 2017 vs ORCID 2016
```

Reconciling these in ORCID/Zotero turns the gate green and unblocks the data refresh / deploy.

## Testing

- End-to-end: built `derived.json` from the real `fetch.py` helpers against live Zotero + ORCID + the committed Scholar snapshot → produces exactly the 5 failures above, exit 1.
- Unit-tested every `check()` branch plus the clean path (accents/case/small-caps/unicode tolerated, ORCID duplicate collapsed by DOI → no problems), empty-ORCID and empty-Scholar (soft-block) guards.
- `flake8` clean; new code formatted to the repo's black config.

https://claude.ai/code/session_017bEnSMHH8c8uhGNYxjnw9E