### PR TITLE
Cross-check: match theses by handle, corroborate year via Scholar

### DIFF
--- a/check_sources.py
+++ b/check_sources.py
@@ -14,10 +14,11 @@ on pushes to main (see the workflow), a non-zero exit aborts before the artifact
 is uploaded, so the site never deploys from inconsistent sources.
 
 Field coverage differs by source: Zotero (CSL-JSON) is richest; ORCID exposes
-title, type, year and DOI per work; Google Scholar's profile listing only
-exposes titles reliably. So Scholar is checked for presence only, while the
-field-level substance check (DOI, preprint-vs-published status, year) is done
-against ORCID. ORCID does not carry volume/page, so those are not cross-checked.
+title, type, year and an identifier (DOI or handle) per work; Google Scholar's
+profile exposes title and a publication year. So the identifier and
+preprint-vs-published status are checked against ORCID, the year against both
+ORCID and Scholar, and Scholar additionally must list every Zotero paper.
+Neither ORCID nor Scholar carries volume/page, so those are not cross-checked.
 """
 
 import argparse
@@ -61,45 +62,50 @@ def scholar_titles(derived):
     return list(value)
 
 
-def check(refs, orcid, scholar):  # noqa: C901
+def scholar_years(derived):
+    return (derived.get('custom_data') or {}).get('scholar_years', {})
+
+
+def check(refs, orcid, scholar, scholar_year_by_title):  # noqa: C901
     """Return a list of human-readable disagreement reasons (empty when clean)."""
     problems = []
 
-    # Index ORCID works both ways: by title (to pair) and by DOI (to collapse
-    # ORCID's per-version duplicates onto the Zotero paper they belong to).
+    # Index ORCID works both ways: by title (to pair) and by identifier (to
+    # collapse ORCID's per-version duplicates onto the Zotero paper they belong
+    # to). Identifiers are DOIs or handles (theses are filed under a handle).
     o_by_title = defaultdict(list)
-    o_by_doi = defaultdict(list)
+    o_by_id = defaultdict(list)
     for work in orcid:
         o_by_title[title_key(work['title'])].append(work)
-        for doi in work.get('dois') or []:
-            o_by_doi[doi].append(work)
+        for ident in work.get('ids') or []:
+            o_by_id[ident].append(work)
 
     z_titles = set()
-    z_dois = set()
+    z_ids = set()
     if not orcid:
         problems.append('no ORCID works to cross-check against')
     for ref in refs:
         z_titles.add(title_key(ref['title']))
-        doi = ref.get('id')  # canonical DOI: the same join key fetch.py builds
-        if doi:
-            z_dois.add(doi)
+        ident = ref.get('id')  # canonical DOI/handle: the join key fetch.py builds
+        if ident:
+            z_ids.add(ident)
         if not orcid:
             continue
-        # Pair on title, falling back to a shared DOI when the titles diverge
-        # by more than the tolerated folds.
-        cands = o_by_title.get(title_key(ref['title'])) or (o_by_doi.get(doi) or [])
+        # Pair on title, falling back to a shared identifier when the titles
+        # diverge by more than the tolerated folds.
+        cands = o_by_title.get(title_key(ref['title'])) or (o_by_id.get(ident) or [])
         if not cands:
             problems.append(f'absent from ORCID: {ref["title"]!r}')
             continue
-        same_doi = [c for c in cands if doi in (c.get('dois') or [])]
-        if not same_doi:
-            orcid_dois = sorted({d for c in cands for d in c.get('dois') or []})
+        same_id = [c for c in cands if ident in (c.get('ids') or [])]
+        if not same_id:
+            orcid_ids = sorted({i for c in cands for i in c.get('ids') or []})
             problems.append(
-                f'DOI mismatch (preprint vs published?): {ref["title"]!r} '
-                f'Zotero {doi} vs ORCID {orcid_dois}'
+                f'identifier mismatch (preprint vs published?): {ref["title"]!r} '
+                f'Zotero {ident} vs ORCID {orcid_ids}'
             )
             continue
-        work = same_doi[0]
+        work = same_id[0]
         z_status = ZOTERO_STATUS.get(ref.get('type'), ref.get('type'))
         o_status = ORCID_STATUS.get(work.get('type'), work.get('type'))
         if z_status != o_status:
@@ -113,23 +119,33 @@ def check(refs, orcid, scholar):  # noqa: C901
                 f'year differs: {ref["title"]!r} Zotero {z_year} vs ORCID {o_year}'
             )
 
-    # ORCID works that match no Zotero paper -- by title or by a shared DOI (the
-    # latter skips ORCID's own duplicate records of papers Zotero does list).
+    # ORCID works that match no Zotero paper -- by title or by a shared
+    # identifier (the latter skips ORCID's own duplicate records of papers
+    # Zotero does list).
     for work in orcid:
         if title_key(work['title']) not in z_titles and not (
-            set(work.get('dois') or []) & z_dois
+            set(work.get('ids') or []) & z_ids
         ):
             problems.append(f'in ORCID but not Zotero: {work["title"]!r}')
 
     # Google Scholar auto-indexes extra items (talks, duplicates) we can't
-    # curate away, so only require it to cover the Zotero papers, and skip the
-    # check entirely when Scholar data is missing (a soft block) rather than
-    # flagging every paper.
+    # curate away, so only require it to cover the Zotero papers (skipping the
+    # check when Scholar data is missing, e.g. a soft block, rather than flagging
+    # every paper), and corroborate the year where Scholar reports one.
     if scholar:
         s_titles = {title_key(t) for t in scholar}
+        s_years = {title_key(t): y for t, y in scholar_year_by_title.items()}
         for ref in refs:
-            if title_key(ref['title']) not in s_titles:
+            key = title_key(ref['title'])
+            if key not in s_titles:
                 problems.append(f'absent from Google Scholar: {ref["title"]!r}')
+                continue
+            z_year, s_year = ref_year(ref), s_years.get(key)
+            if z_year and s_year and z_year != s_year:
+                problems.append(
+                    f'year differs: {ref["title"]!r} '
+                    f'Zotero {z_year} vs Google Scholar {s_year}'
+                )
 
     return problems
 
@@ -143,6 +159,7 @@ def main(args):
         derived.get('references', []),
         derived.get('orcid', []),
         scholar_titles(derived),
+        scholar_years(derived),
     )
     if not problems:
         print('publication sources agree')

--- a/fetch.py
+++ b/fetch.py
@@ -95,18 +95,32 @@ def norm_desc(s):
     return s
 
 
-def parse_scholar_profile_html(html):
+def _scholar_rows(html):
     soup = BeautifulSoup(html, "html.parser")
-    return {
-        row.select_one(".gsc_a_at").get_text(strip=True): int(
-            row.select_one(".gsc_a_c").get_text(strip=True) or 0
-        )
-        for row in soup.select("#gsc_a_t .gsc_a_tr")
-    }
+    for row in soup.select("#gsc_a_t .gsc_a_tr"):
+        title = row.select_one(".gsc_a_at").get_text(strip=True)
+        cites = int(row.select_one(".gsc_a_c").get_text(strip=True) or 0)
+        year_cell = row.select_one(".gsc_a_y")
+        year = year_cell.get_text(strip=True) if year_cell else ''
+        yield title, cites, year or None
+
+
+def parse_scholar_profile_html(html):
+    return {title: cites for title, cites, _ in _scholar_rows(html)}
+
+
+def parse_scholar_years_html(html):
+    # The profile lists a publication year per row; check_sources.py uses it as a
+    # third witness on each paper's year. Rows without a year are skipped.
+    return {title: year for title, _, year in _scholar_rows(html) if year}
 
 
 def parse_scholar_profile(path):
     return parse_scholar_profile_html(path.read_text())
+
+
+def parse_scholar_years(path):
+    return parse_scholar_years_html(path.read_text())
 
 
 def published_scholar_citations():
@@ -116,6 +130,15 @@ def published_scholar_citations():
         ]
     except (requests.exceptions.RequestException, LookupError, KeyError, ValueError):
         return {'timestamp': '1970-01-01T00:00:00', 'value': {}}
+
+
+def published_scholar_years():
+    try:
+        return json.loads(reuse_data.latest_derived_bytes())['custom_data'][
+            'scholar_years'
+        ]
+    except (requests.exceptions.RequestException, LookupError, KeyError, ValueError):
+        return {}
 
 
 def _ensure_nltk():
@@ -187,8 +210,8 @@ def fetch_orcid(cache):
     """Flat list of the public ORCID works, one record per work summary.
 
     ORCID lists each work's versions (preprint, published, ...) under the same
-    title, so duplicates are expected; check_sources.py collapses them by DOI.
-    DOIs are canonicalised to the same `10.prefix/suffix` join key Zotero uses.
+    title, so duplicates are expected; check_sources.py collapses them by
+    identifier. Identifiers are canonicalised to the same join key Zotero uses.
     """
     data = cache.get(ORCID_WORKS_URL, headers=ORCID_HEADERS)
     works = []
@@ -197,13 +220,18 @@ def fetch_orcid(cache):
             title = (((summary.get('title') or {}).get('title')) or {}).get('value')
             if not title:
                 continue
-            dois = sorted(
+            # Match on DOIs *and* handles. Theses are identified by a handle
+            # (e.g. a dspace/edoc handle), which ORCID files under external-id
+            # type "handle" and Zotero keeps in its DOI field; collecting only
+            # DOIs would leave a thesis with no identifier to join on.
+            # canonical_doi resolves shortDOIs and lower-cases handles unchanged.
+            ids = sorted(
                 {
                     canonical_doi(eid['external-id-value'], cache)
                     for eid in (summary.get('external-ids') or {}).get(
                         'external-id', []
                     )
-                    if eid.get('external-id-type') == 'doi'
+                    if eid.get('external-id-type') in ('doi', 'handle')
                 }
             )
             pubdate = summary.get('publication-date') or {}
@@ -211,7 +239,7 @@ def fetch_orcid(cache):
             works.append(
                 {
                     'title': title,
-                    'dois': dois,
+                    'ids': ids,
                     'type': summary.get('type'),
                     'year': str(year) if year else None,
                 }
@@ -305,14 +333,17 @@ def update_from_web(ctx, cache):  # noqa: C901
                         time.sleep(2)
                         continue
                     raise
-                return parse_scholar_profile_html(r.text)
+                return r.text
 
         # Google Scholar blocks datacenter/CI IPs; on failure fall back to the
         # committed profile snapshot instead of failing the whole fetch.
         try:
-            ctx['scholar_cites'] = cache.get_custom('scholar', func)
+            html = cache.get_custom('scholar', func)
         except requests.exceptions.RequestException as e:
             logging.warning('Could not fetch Google Scholar profile: %r', e)
+        else:
+            ctx['scholar_cites'] = parse_scholar_profile_html(html)
+            ctx['scholar_years'] = parse_scholar_years_html(html)
 
     ctx['references'] = fetch_references(cache)
     # ORCID only gates the push-to-main cross-check; a transient outage
@@ -348,6 +379,7 @@ def update_from_web(ctx, cache):  # noqa: C901
     }
     if ctx.get("scholar_cites"):
         cites = ctx["scholar_cites"]
+        years = ctx.get("scholar_years", {})
         ts = datetime.now().isoformat()
     else:
         path = Path("assets") / "_Jan Hermann_ - _Google Scholar_.html"
@@ -359,13 +391,18 @@ def update_from_web(ctx, cache):  # noqa: C901
             ts := datetime.fromtimestamp(path.stat().st_mtime).isoformat()
         ) > scholar_citations["timestamp"] or not scholar_citations["value"]:
             cites = parse_scholar_profile(path)
+            years = parse_scholar_years(path)
         else:
             cites = scholar_citations["value"]
             ts = scholar_citations["timestamp"]
+            # Older published artifacts predate scholar_years; absent it the
+            # cross-check simply skips Scholar's year corroboration.
+            years = published_scholar_years()
     ctx["custom_data"]["scholar_citations"] = {
         "timestamp": ts,
         "value": cites,
     }
+    ctx["custom_data"]["scholar_years"] = years
     for title, cite in cites.items():
         key = reduce_sc(title.lower())[:120]
         # Scholar lists publications that aren't tracked as references here


### PR DESCRIPTION
Two follow-ups to the Zotero/ORCID/Scholar cross-check (#32), both validated against live data.

## 1. Match theses by handle, not just DOI (bug fix)

The scheduled run on `main` failed with a spurious "DOI mismatch" on a thesis. Root cause: two theses are identified by a **handle**, not a DOI:

- *"Nonlocal correlation in density functional theory"* — Zotero stores the handle `20.500.11956/52661` in its DOI field; ORCID files it under external-id type **`handle`**.
- *"Towards unified density-functional model…"* — Zotero `10/g5v9` (shortDOI → `10.18452/18706`), which ORCID has as a `doi`.

`fetch_orcid` only collected `external-id-type == 'doi'`, so it **silently dropped ORCID's `handle` ids** — leaving the thesis with no identifier to join on.

**Fix (structural, not an allowlist):** a handle is a legitimate persistent identifier, so the check now compares a work's *identifier set* regardless of whether ORCID typed it `doi` or `handle`. `fetch_orcid` collects both (`canonical_doi` lower-cases handles unchanged and still resolves shortDOIs), and the per-work `dois` field is renamed to `ids`. The thesis data in *both* sources is correct — there's no DOI for a dspace thesis — so this fixes the check, not the data. A genuinely mismatched thesis handle still flags (covered in tests).

## 2. Corroborate the year against Google Scholar (feature)

The profile listing carries a per-row year (`.gsc_a_y`) the parser was discarding. It's now kept (in `custom_data.scholar_years`) and the cross-check compares it to Zotero's — a third independent witness on each paper's year, on top of ORCID. Verified clean: all 37 Zotero papers match a Scholar row with an identical year. Degrades gracefully when Scholar data is missing (soft block) or on older artifacts that predate the field.

## Result

Rebuilt against live Zotero + ORCID + Scholar, the full cross-check now **passes** (exit 0) — both theses match, years corroborate, and the earlier source drift has since been reconciled.

## Testing

- End-to-end: rebuilt `derived.json` from the real `fetch.py` helpers → `check_sources` exits 0; both ORCID thesis records resolve to `['10.18452/18706']` / `['20.500.11956/52661']` and match.
- Unit-tested the clean path (thesis matched by handle, ORCID duplicate collapsed by id, accents/unicode tolerated, Scholar years agree) and each failure branch (identifier mismatch for both a journal preprint-vs-published and a mismatched thesis handle; Scholar-year disagreement).
- `flake8` clean. (Two pre-existing black nits in unrelated lines left untouched.)

https://claude.ai/code/session_017bEnSMHH8c8uhGNYxjnw9E

---
_Generated by [Claude Code](https://claude.ai/code/session_017bEnSMHH8c8uhGNYxjnw9E)_