### PR TITLE
Cross-check: flag preprint-still-in-Zotero and compare venues

### DIFF
--- a/check_sources.py
+++ b/check_sources.py
@@ -8,16 +8,22 @@ the same papers and that, for each paper, ORCID's substance matches Zotero's.
 
 The only differences tolerated are accents, letter case, and unicode-vs-ascii
 spelling of the same character (see `common.fold_text`); anything else -- a
-paper present in one source but not another, a preprint-vs-published DOI/type
-mismatch, a differing year -- is a regression. Run at the end of the fetch job
-on pushes to main (see the workflow), a non-zero exit aborts before the artifact
-is uploaded, so the site never deploys from inconsistent sources.
+paper present in one source but not another, a preprint-vs-published mismatch, a
+differing year or venue -- is a regression. Run at the end of the fetch job on
+pushes to main (see the workflow), a non-zero exit aborts before the artifact is
+uploaded, so the site never deploys from inconsistent sources.
 
 Field coverage differs by source: Zotero (CSL-JSON) is richest; ORCID exposes
-title, type, year and an identifier (DOI or handle) per work; Google Scholar's
-profile exposes title and a publication year. So the identifier and
-preprint-vs-published status are checked against ORCID, the year against both
-ORCID and Scholar, and Scholar additionally must list every Zotero paper.
+title, type, year, an identifier (DOI or handle) and a journal per work; Google
+Scholar's profile exposes title, year and venue. So:
+
+- the identifier and preprint-vs-published status are checked against ORCID
+  (including flagging a paper ORCID lists as published while Zotero still has it
+  as a preprint),
+- the year is corroborated against both ORCID and Scholar,
+- the venue is compared across all three, folded to a common ISO-4 abbreviation,
+- and Scholar must additionally list every Zotero paper.
+
 Neither ORCID nor Scholar carries volume/page, so those are not cross-checked.
 """
 
@@ -66,7 +72,13 @@ def scholar_years(derived):
     return (derived.get('custom_data') or {}).get('scholar_years', {})
 
 
-def check(refs, orcid, scholar, scholar_year_by_title):  # noqa: C901
+def scholar_venues(derived):
+    return (derived.get('custom_data') or {}).get('scholar_venues', {})
+
+
+def check(  # noqa: C901
+    refs, orcid, scholar, scholar_year_by_title, scholar_venue_by_title
+):
     """Return a list of human-readable disagreement reasons (empty when clean)."""
     problems = []
 
@@ -80,12 +92,17 @@ def check(refs, orcid, scholar, scholar_year_by_title):  # noqa: C901
         for ident in work.get('ids') or []:
             o_by_id[ident].append(work)
 
+    # Scholar venues arrive keyed by Scholar's raw title; re-key on title_key so
+    # they pair with references the same way everything else does.
+    s_venues = {title_key(t): v for t, v in (scholar_venue_by_title or {}).items()}
+
     z_titles = set()
     z_ids = set()
     if not orcid:
         problems.append('no ORCID works to cross-check against')
     for ref in refs:
-        z_titles.add(title_key(ref['title']))
+        key = title_key(ref['title'])
+        z_titles.add(key)
         ident = ref.get('id')  # canonical DOI/handle: the join key fetch.py builds
         if ident:
             z_ids.add(ident)
@@ -93,10 +110,27 @@ def check(refs, orcid, scholar, scholar_year_by_title):  # noqa: C901
             continue
         # Pair on title, falling back to a shared identifier when the titles
         # diverge by more than the tolerated folds.
-        cands = o_by_title.get(title_key(ref['title'])) or (o_by_id.get(ident) or [])
+        cands = o_by_title.get(key) or (o_by_id.get(ident) or [])
         if not cands:
             problems.append(f'absent from ORCID: {ref["title"]!r}')
             continue
+        z_status = ZOTERO_STATUS.get(ref.get('type'), ref.get('type'))
+        # A paper ORCID records as a published journal article while Zotero still
+        # lists it as a preprint: Zotero should be advanced to the published
+        # version. ORCID keeps both versions, so the preprint identifier still
+        # matches -- this is the drift the plain identifier check can't see.
+        if z_status == 'preprint':
+            published = [
+                c for c in cands if ORCID_STATUS.get(c.get('type')) == 'journal'
+            ]
+            if published:
+                pub_ids = sorted({i for c in published for i in c.get('ids') or []})
+                problems.append(
+                    f'published on ORCID but still a preprint in Zotero: '
+                    f'{ref["title"]!r} (Zotero preprint {ident}; '
+                    f'ORCID published {pub_ids})'
+                )
+                continue
         same_id = [c for c in cands if ident in (c.get('ids') or [])]
         if not same_id:
             orcid_ids = sorted({i for c in cands for i in c.get('ids') or []})
@@ -106,7 +140,6 @@ def check(refs, orcid, scholar, scholar_year_by_title):  # noqa: C901
             )
             continue
         work = same_id[0]
-        z_status = ZOTERO_STATUS.get(ref.get('type'), ref.get('type'))
         o_status = ORCID_STATUS.get(work.get('type'), work.get('type'))
         if z_status != o_status:
             problems.append(
@@ -118,6 +151,20 @@ def check(refs, orcid, scholar, scholar_year_by_title):  # noqa: C901
             problems.append(
                 f'year differs: {ref["title"]!r} Zotero {z_year} vs ORCID {o_year}'
             )
+        # Venue: Zotero's container-title-short, ORCID's journal-title and
+        # Scholar's venue, all folded to the same ISO-4 abbreviation (fetch.py
+        # abbreviates ORCID/Scholar; Zotero already stores the short form). Only
+        # journal articles -- a chapter/thesis "venue" isn't a journal.
+        if ref.get('type') == 'article-journal':
+            venues = {
+                'Zotero': ref.get('container-title-short'),
+                'ORCID': work.get('journal'),
+                'Google Scholar': s_venues.get(key),
+            }
+            folded = {src: title_key(v) for src, v in venues.items() if v}
+            if len(set(folded.values())) > 1:
+                detail = ', '.join(f'{src} {venues[src]!r}' for src in folded)
+                problems.append(f'venue differs: {ref["title"]!r} {detail}')
 
     # ORCID works that match no Zotero paper -- by title or by a shared
     # identifier (the latter skips ORCID's own duplicate records of papers
@@ -160,6 +207,7 @@ def main(args):
         derived.get('orcid', []),
         scholar_titles(derived),
         scholar_years(derived),
+        scholar_venues(derived),
     )
     if not problems:
         print('publication sources agree')

--- a/fetch.py
+++ b/fetch.py
@@ -102,17 +102,33 @@ def _scholar_rows(html):
         cites = int(row.select_one(".gsc_a_c").get_text(strip=True) or 0)
         year_cell = row.select_one(".gsc_a_y")
         year = year_cell.get_text(strip=True) if year_cell else ''
-        yield title, cites, year or None
+        # The second grey line is the venue, e.g. "J. Chem. Inf. Model. 65 (18),
+        # 9576-9580, 2025". Keep only the name: everything before the first
+        # volume number, with a truncation ellipsis trimmed off.
+        grays = row.select(".gs_gray")
+        venue = grays[1].get_text(strip=True) if len(grays) > 1 else ''
+        venue = re.split(r'\s+(?=\d)', venue, 1)[0].strip().rstrip('…').strip()
+        yield title, cites, year or None, venue or None
 
 
 def parse_scholar_profile_html(html):
-    return {title: cites for title, cites, _ in _scholar_rows(html)}
+    return {title: cites for title, cites, _, _ in _scholar_rows(html)}
 
 
 def parse_scholar_years_html(html):
     # The profile lists a publication year per row; check_sources.py uses it as a
     # third witness on each paper's year. Rows without a year are skipped.
-    return {title: year for title, _, year in _scholar_rows(html) if year}
+    return {title: year for title, _, year, _ in _scholar_rows(html) if year}
+
+
+def parse_scholar_venues_html(html):
+    # ISO-4 abbreviation of each row's venue, so check_sources.py can compare it
+    # to Zotero's container-title-short and ORCID's journal-title on equal terms.
+    return {
+        title: journal_abbrev(venue)
+        for title, _, _, venue in _scholar_rows(html)
+        if venue
+    }
 
 
 def parse_scholar_profile(path):
@@ -121,6 +137,10 @@ def parse_scholar_profile(path):
 
 def parse_scholar_years(path):
     return parse_scholar_years_html(path.read_text())
+
+
+def parse_scholar_venues(path):
+    return parse_scholar_venues_html(path.read_text())
 
 
 def published_scholar_citations():
@@ -136,6 +156,15 @@ def published_scholar_years():
     try:
         return json.loads(reuse_data.latest_derived_bytes())['custom_data'][
             'scholar_years'
+        ]
+    except (requests.exceptions.RequestException, LookupError, KeyError, ValueError):
+        return {}
+
+
+def published_scholar_venues():
+    try:
+        return json.loads(reuse_data.latest_derived_bytes())['custom_data'][
+            'scholar_venues'
         ]
     except (requests.exceptions.RequestException, LookupError, KeyError, ValueError):
         return {}
@@ -161,6 +190,23 @@ def abbreviate_journal(name):
     from iso4 import abbreviate
 
     return abbreviate(name, periods=True, disambiguation_langs=['en'])
+
+
+def journal_abbrev(name):
+    """ISO-4 abbreviation of a venue, tolerant of missing/odd input.
+
+    Used to fold each source's venue (ORCID's journal-title, Scholar's venue
+    line) onto the same abbreviated form Zotero already stores in
+    container-title-short, so the cross-check can compare them. Returns None for
+    empty input and falls back to the raw name if abbreviation fails (e.g. a
+    preprint server, which the venue check ignores anyway).
+    """
+    if not name:
+        return None
+    try:
+        return abbreviate_journal(name)
+    except Exception:
+        return name
 
 
 def canonical_doi(doi, cache):
@@ -236,12 +282,14 @@ def fetch_orcid(cache):
             )
             pubdate = summary.get('publication-date') or {}
             year = ((pubdate.get('year') or {}).get('value')) if pubdate else None
+            journal = (summary.get('journal-title') or {}).get('value')
             works.append(
                 {
                     'title': title,
                     'ids': ids,
                     'type': summary.get('type'),
                     'year': str(year) if year else None,
+                    'journal': journal_abbrev(journal),
                 }
             )
     return works
@@ -344,6 +392,7 @@ def update_from_web(ctx, cache):  # noqa: C901
         else:
             ctx['scholar_cites'] = parse_scholar_profile_html(html)
             ctx['scholar_years'] = parse_scholar_years_html(html)
+            ctx['scholar_venues'] = parse_scholar_venues_html(html)
 
     ctx['references'] = fetch_references(cache)
     # ORCID only gates the push-to-main cross-check; a transient outage
@@ -380,6 +429,7 @@ def update_from_web(ctx, cache):  # noqa: C901
     if ctx.get("scholar_cites"):
         cites = ctx["scholar_cites"]
         years = ctx.get("scholar_years", {})
+        venues = ctx.get("scholar_venues", {})
         ts = datetime.now().isoformat()
     else:
         path = Path("assets") / "_Jan Hermann_ - _Google Scholar_.html"
@@ -392,17 +442,20 @@ def update_from_web(ctx, cache):  # noqa: C901
         ) > scholar_citations["timestamp"] or not scholar_citations["value"]:
             cites = parse_scholar_profile(path)
             years = parse_scholar_years(path)
+            venues = parse_scholar_venues(path)
         else:
             cites = scholar_citations["value"]
             ts = scholar_citations["timestamp"]
-            # Older published artifacts predate scholar_years; absent it the
-            # cross-check simply skips Scholar's year corroboration.
+            # Older published artifacts predate scholar_years/venues; absent them
+            # the cross-check simply skips Scholar's year/venue corroboration.
             years = published_scholar_years()
+            venues = published_scholar_venues()
     ctx["custom_data"]["scholar_citations"] = {
         "timestamp": ts,
         "value": cites,
     }
     ctx["custom_data"]["scholar_years"] = years
+    ctx["custom_data"]["scholar_venues"] = venues
     for title, cite in cites.items():
         key = reduce_sc(title.lower())[:120]
         # Scholar lists publications that aren't tracked as references here


### PR DESCRIPTION
Two additions to the Zotero/ORCID/Scholar cross-check, both empirically validated against live data.

## 1. Flag "published on ORCID but still a preprint in Zotero"

The drift that prompted this: a paper can be published (a `journal-article` record on ORCID, the journal venue on Scholar) while Zotero still lists it as a **preprint**. Because ORCID keeps *both* the preprint and published versions under one title, the preprint identifier still matches and the existing identifier check stays silent — yet Zotero is stale and should be advanced to the published version.

The check now flags this directly. On current data it catches exactly:
```
- published on ORCID but still a preprint in Zotero: 'Chemical space exploration with artificial "mindless" molecules'
    (Zotero preprint 10.26434/chemrxiv-2025-rdsd0; ORCID published ['10.1021/acs.jcim.5c01364'])
```
(It supersedes the older "identifier mismatch" message for the preprint case, so there's no double-reporting — e.g. "Accurate Chemistry Collection" would have shown one clear message, not two.)

## 2. Compare the publication venue across all three sources

Each source spells the venue differently — Zotero stores the ISO-4 abbreviation (`J. Chem. Phys.`), ORCID the full name (`The Journal of Chemical Physics`), Scholar the name plus trailing volume/issue/pages (`J. Chem. Inf. Model. 65 (18), 9576-…`). So a raw comparison would be all false positives.

`fetch.py` now folds ORCID's `journal-title` and Scholar's venue line to the **same ISO-4 abbreviation** Zotero already stores in `container-title-short`, reusing the existing `abbreviate_journal` (which is built to match Better BibTeX). The check then compares them folded (case/accents/punctuation-insensitive).

**Validated: all 29 journal articles' venues agree across all three sources after normalization — 0 false positives** (including edge cases like ORCID's `J Chem Phys` with no periods and Scholar's lowercased `J. chem. phys.`).

### How the venue data flows
- ORCID works now carry an abbreviated `journal` field.
- Scholar's venue is parsed and abbreviated into `custom_data.scholar_venues` (alongside the year), with the snapshot/soft-block fallbacks handled like the year.
- Zotero already has `container-title-short`.
- Venue is only compared for journal articles (a chapter/thesis "venue" isn't a journal).

## Testing
- End-to-end against live Zotero + ORCID + Scholar: the only flag is the preprint-still-in-Zotero one above; **0 venue mismatches**; Scholar venue genuinely participates (29/29 journal articles matched).
- Unit-tested each new branch: preprint-published-on-ORCID flag; preprint-only (no published version) stays clean; 3-way venue mismatch lists all three sources; venue agreement across different spellings is clean.
- `flake8` and `black` clean on the changed files.

https://claude.ai/code/session_017bEnSMHH8c8uhGNYxjnw9E

---
_Generated by [Claude Code](https://claude.ai/code/session_017bEnSMHH8c8uhGNYxjnw9E)_