### PR TITLE
Add STC 2025 contributed talk to CV

### DIFF
--- a/data/cv.yaml
+++ b/data/cv.yaml
@@ -251,7 +251,7 @@ presentations:
   - title: "Skala: Accurate and scalable exchange-correlation with deep learning"
     event: Symposium on Theoretical Chemistry
     where: Berlin, Germany
-    event_url: https://www.bcp.fu-berlin.de/en/stc2025/index.html
+    url: https://www.bcp.fu-berlin.de/en/stc2025/long-program/abstracts/Abstract_Hermann/index.html
     year: 2025
   - title: Approaching exact solutions of the electronic Schrödinger equation with deep quantum Monte Carlo
     event: APS March Meeting

--- a/data/cv.yaml
+++ b/data/cv.yaml
@@ -248,6 +248,11 @@ presentations:
     event_url: https://molssi.org/2018/03/26/molssi-workshop-on-python-for-quantum-chemistry-and-materials-simulation/
     year: 2018
   contributed:
+  - title: "Skala: Accurate and scalable exchange-correlation with deep learning"
+    event: Symposium on Theoretical Chemistry
+    where: Berlin, Germany
+    event_url: https://www.bcp.fu-berlin.de/en/stc2025/index.html
+    year: 2025
   - title: Approaching exact solutions of the electronic Schrödinger equation with deep quantum Monte Carlo
     event: APS March Meeting
     note: virtual


### PR DESCRIPTION
Adds the talk given at the **61st Symposium on Theoretical Chemistry (STC 2025)**, Berlin, Germany (Sep 22–26, 2025), to the contributed talks list in `data/cv.yaml`.

- **Title:** Skala: Accurate and scalable exchange-correlation with deep learning
- **Event:** Symposium on Theoretical Chemistry
- **Where:** Berlin, Germany
- **Year:** 2025

The talk was a 20-minute contributed slot (Thu Sep 25, 12:10–12:30), so it's filed under `contributed` rather than `invited`. The template groups by year and sorts descending, so it renders at the top of the talks list automatically.

https://claude.ai/code/session_01QdeBaKdaHLKETPr7tVU66h

---
_Generated by [Claude Code](https://claude.ai/code/session_01QdeBaKdaHLKETPr7tVU66h)_