### PR TITLE
Add Web of Science fetch and cross-check to CI

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -137,8 +137,8 @@ jobs:
         run: poetry run make check
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Cross-check Zotero, ORCID and Google Scholar
-        # Gate production deploys on the three publication sources agreeing.
+      - name: Cross-check Zotero, ORCID, Google Scholar and Web of Science
+        # Gate production deploys on the publication sources agreeing.
         # Runs whenever fetch produces data that will be published: the daily
         # schedule and manual dispatch (both deploy to main), plus a push that
         # changed fetch inputs (fetch already runs, so no extra crawl). The

--- a/check_sources.py
+++ b/check_sources.py
@@ -1,10 +1,11 @@
 #!/usr/bin/env python3
-"""Cross-check that the three publication sources agree.
+"""Cross-check that the publication sources agree.
 
 The site's reference list comes from the Zotero "My Publications" library;
-ORCID and Google Scholar are independent records of the same publications. This
-reads a freshly fetched `build/derived.json` and verifies that all three list
-the same papers and that, for each paper, ORCID's substance matches Zotero's.
+ORCID, Google Scholar and Web of Science are independent records of the same
+publications. This reads a freshly fetched `build/derived.json` and verifies
+that they list the same papers and that, for each paper, ORCID's substance
+matches Zotero's.
 
 The only differences tolerated are accents, letter case, and unicode-vs-ascii
 spelling of the same character (see `common.fold_text`); anything else -- a
@@ -22,7 +23,10 @@ Scholar's profile exposes title, year and venue. So:
   as a preprint),
 - the year is corroborated against both ORCID and Scholar,
 - the venue is compared across all three, folded to a common ISO-4 abbreviation,
-- and Scholar must additionally list every Zotero paper.
+- Scholar must additionally list every Zotero paper,
+- and Web of Science must list every Zotero paper it would index -- i.e. every
+  published one, since WoS doesn't index preprints, theses or book chapters --
+  and must carry no unexpected record of its own (see WOS_ALLOWED_EXTRAS).
 
 Neither ORCID nor Scholar carries volume/page, so those are not cross-checked.
 """
@@ -52,6 +56,28 @@ ORCID_STATUS = {
     'book-chapter': 'chapter',
     'dissertation-thesis': 'thesis',
     'dissertation': 'thesis',
+}
+
+# Web of Science (via Publons) indexes the published literature only -- not
+# preprints, theses or book chapters -- so a Zotero item of one of those types
+# legitimately has no WoS counterpart and isn't required to appear there.
+WOS_OPTIONAL_STATUS = {'preprint', 'chapter', 'thesis'}
+
+# WoS records that have no Zotero counterpart yet are expected, so the
+# cross-check tolerates them rather than flagging a regression. Keyed by the
+# same join identifier fetch.py builds -- the canonical DOI where WoS has one,
+# else the WoS/Publons accession id:
+WOS_ALLOWED_EXTRAS = {
+    # DFTB+ erratum ("vol 152, 124101, 2020"), which WoS indexes as a record
+    # distinct from the article itself (Zotero keeps only the article).
+    '10.1063/5.0103026',
+    # Duplicate preprint of the deep-VMC fixed-node paper; its published version
+    # (10.1063/5.0032836) is the record Zotero lists and WoS also carries.
+    'PPRN:11490275',
+    # Two records mis-attributed to this profile -- a cochlear-implant preprint
+    # and a 2006 laser-ablation paper, both by a different J. Hermann.
+    '10.1101/19000711',
+    'PPRN:49096155',
 }
 
 
@@ -197,6 +223,42 @@ def check(  # noqa: C901
     return problems
 
 
+def check_wos(refs, wos):
+    """Cross-check the Zotero list against Web of Science (empty = skipped).
+
+    Joins on the canonical identifier fetch.py builds for both sides (DOI, else
+    the WoS accession id). WoS must list every Zotero paper it would index --
+    preprints, theses and chapters excepted, since WoS doesn't index those --
+    and must not carry an unexpected record of its own (WOS_ALLOWED_EXTRAS lists
+    the known, tolerated ones). Returns a list of disagreement reasons.
+    """
+    problems = []
+    if not wos:
+        problems.append('no Web of Science works to cross-check against')
+        return problems
+    wos_ids = {w['id'] for w in wos if w['id']}
+    # Every Zotero paper WoS is expected to index must be present.
+    for ref in refs:
+        status = ZOTERO_STATUS.get(ref.get('type'), ref.get('type'))
+        if status in WOS_OPTIONAL_STATUS:
+            continue
+        ident = ref.get('id')
+        if ident and ident not in wos_ids:
+            problems.append(f'absent from Web of Science: {ref["title"]!r}')
+    # WoS records with no Zotero counterpart, beyond the known-allowed extras.
+    zotero_ids = {ref['id'] for ref in refs if ref.get('id')}
+    for work in wos:
+        key = work['id'] or work.get('accession')
+        if key in WOS_ALLOWED_EXTRAS:
+            continue
+        if work['id'] and work['id'] in zotero_ids:
+            continue
+        problems.append(
+            f'in Web of Science but not Zotero: {work["title"]!r} ({key})'
+        )
+    return problems
+
+
 def main(args):
     p = argparse.ArgumentParser(description=__doc__)
     p.add_argument('derived', nargs='?', default='build/derived.json', type=Path)
@@ -209,6 +271,7 @@ def main(args):
         scholar_years(derived),
         scholar_venues(derived),
     )
+    problems += check_wos(derived.get('references', []), derived.get('wos', []))
     if not problems:
         print('publication sources agree')
         return

--- a/fetch.py
+++ b/fetch.py
@@ -48,6 +48,12 @@ ZOTERO_REFS_URL = (
 ORCID_ID = '0000-0002-2779-0749'
 ORCID_WORKS_URL = f'https://pub.orcid.org/v3.0/{ORCID_ID}/works'
 ORCID_HEADERS = {'Accept': 'application/json'}
+# Web of Science publication list, exposed through the Publons "WoS-OP" API for
+# the same researcher profile reviews() reads its review count from. WoS indexes
+# the published literature, so check_sources.py uses it to catch a published
+# paper missing from Zotero (and an unexpected record on the WoS side). The
+# academic record carries the paginated publication-list URL.
+WOS_ACADEMIC_URL = f'https://publons.com/api/v2/academic/{ORCID_ID}/'
 
 
 class Cache:
@@ -295,6 +301,36 @@ def fetch_orcid(cache):
     return works
 
 
+def fetch_wos(cache):
+    """Flat list of the Web of Science (Publons) publication records.
+
+    The academic record exposes a paginated publication-list URL; each record is
+    reduced to the fields the cross-check needs -- the title, the publication
+    year, and a join key: the canonical DOI where WoS has one (resolved and
+    lower-cased the same way Zotero's identifiers are, so the two sides compare
+    equal), else the WoS/Publons accession id (e.g. a ``PPRN:...`` preprint id)
+    so DOI-less records can still be named.
+    """
+    headers = {'authorization': f'Token {os.environ["PUBLONS_TOKEN"]}'}
+    url = cache.get(WOS_ACADEMIC_URL, headers=headers)['publications']['url']
+    works = []
+    while url:
+        page = cache.get(url, headers=headers)
+        for record in page['results']:
+            pub = record['publication']
+            doi = pub['ids'].get('doi')
+            works.append(
+                {
+                    'title': pub['title'],
+                    'id': canonical_doi(doi, cache) if doi else None,
+                    'accession': pub['ids'].get('ut') or None,
+                    'year': (pub.get('date_published') or '')[:4] or None,
+                }
+            )
+        url = page.get('next')
+    return works
+
+
 def update_from_web(ctx, cache):  # noqa: C901
     def stars(item):
         if 'github' in item:
@@ -319,7 +355,7 @@ def update_from_web(ctx, cache):  # noqa: C901
 
     def reviews(ctx):
         n_reviews = cache.get(
-            'https://publons.com/api/v2/academic/0000-0002-2779-0749/',
+            WOS_ACADEMIC_URL,
             headers={'authorization': f'Token {os.environ["PUBLONS_TOKEN"]}'},
         )['reviews']['pre']['count']
         ctx['_n_reviews'] = n_reviews
@@ -403,6 +439,13 @@ def update_from_web(ctx, cache):  # noqa: C901
     except requests.exceptions.RequestException as e:
         logging.warning('Could not fetch ORCID works: %r', e)
         ctx['orcid'] = []
+    # Same tolerance for Web of Science: a fetch failure leaves an empty list,
+    # which check_sources.py reports as "no Web of Science data" on main.
+    try:
+        ctx['wos'] = fetch_wos(cache)
+    except requests.exceptions.RequestException as e:
+        logging.warning('Could not fetch Web of Science works: %r', e)
+        ctx['wos'] = []
     with concurrent.futures.ThreadPoolExecutor(max_workers=4) as pool:
         futures = [
             pool.submit(func, x)
@@ -478,6 +521,7 @@ def extract_derived(ctx):
         },
         'references': ctx['references'],
         'orcid': ctx.get('orcid', []),
+        'wos': ctx.get('wos', []),
         'n_reviews': ctx.get('_n_reviews'),
         'custom_data': ctx['custom_data'],
     }


### PR DESCRIPTION
## What

Adds the **Web of Science** publication list as a fourth source to the publication cross-check that gates production deploys (alongside Zotero, ORCID and Google Scholar).

## How

- **`fetch.py`** — new `fetch_wos()` pulls the WoS publication list via the Publons WoS-OP API (`/academic/{orcid}/` → paginated `publications` URL), the same researcher profile the review count already comes from. Each record is reduced to title, year, and a join key: the canonical DOI (resolved + lower-cased the same way Zotero's identifiers are) or the WoS/Publons accession id for DOI-less records. Wired into the fetch alongside ORCID (same graceful-on-failure handling) and emitted under a new `wos` key in `derived.json`. The existing `reviews()` URL now reuses the shared `WOS_ACADEMIC_URL` constant.
- **`check_sources.py`** — new `check_wos()` joins Zotero and WoS on the canonical identifier and requires WoS to list every Zotero paper it would index, and to carry no unexpected record of its own.
- **`.github/workflows/build.yaml`** — renamed the cross-check step to include Web of Science (no gating change; the step already runs `make check-sources`).

## Cross-check rules

- **Ignored in general:** WoS doesn't index preprints, theses or book chapters, so Zotero items of those types are not required to appear (`WOS_OPTIONAL_STATUS`). This covers all current Zotero-only items (a book chapter, two theses, three recent arXiv preprints).
- **Explicit exceptions** (`WOS_ALLOWED_EXTRAS`) for the four known WoS-only records:
  - `10.1063/5.0103026` — DFTB+ erratum, indexed by WoS as a record distinct from the article
  - `PPRN:11490275` — duplicate preprint of the deep-VMC fixed-node paper (its published version `10.1063/5.0032836` is the one both list)
  - `10.1101/19000711` — cochlear-implant preprint, a different J. Hermann
  - `PPRN:49096155` — 2006 laser-ablation paper, a different J. Hermann

## Validation

Against live data: 35 WoS records vs 37 Zotero refs → `check_wos` reports **0 problems**; empty WoS → reported as missing data (mirrors ORCID). `flake8` clean. `check_derived.py` ignores the new `wos` key (it only inspects software/references/n_reviews/scholar).

https://claude.ai/code/session_0139vLcgumc1FtWqteNhcyeM

---
_Generated by [Claude Code](https://claude.ai/code/session_0139vLcgumc1FtWqteNhcyeM)_