### PR TITLE
Skip WoS review count on a 429 instead of failing the fetch

### DIFF
--- a/fetch.py
+++ b/fetch.py
@@ -158,6 +158,13 @@ def published_scholar_citations():
         return {'timestamp': '1970-01-01T00:00:00', 'value': {}}
 
 
+def published_n_reviews():
+    try:
+        return json.loads(reuse_data.latest_derived_bytes())['n_reviews']
+    except (requests.exceptions.RequestException, LookupError, KeyError, ValueError):
+        return None
+
+
 def published_scholar_years():
     try:
         return json.loads(reuse_data.latest_derived_bytes())['custom_data'][
@@ -312,18 +319,10 @@ def fetch_wos(cache):
     so DOI-less records can still be named.
     """
     headers = {'authorization': f'Token {os.environ["PUBLONS_TOKEN"]}'}
-    # Route through the same residential proxy as Google Scholar when
-    # configured; Publons/WoS also blocks datacenter/CI IPs. SCHOLAR_PROXY is
-    # a full proxy URL, e.g. http://user:pass@gw.dataimpulse.com:823.
-    proxies = None
-    if proxy := os.environ.get('SCHOLAR_PROXY'):
-        proxies = {'http': proxy, 'https': proxy}
-    url = cache.get(WOS_ACADEMIC_URL, headers=headers, proxies=proxies)[
-        'publications'
-    ]['url']
+    url = cache.get(WOS_ACADEMIC_URL, headers=headers)['publications']['url']
     works = []
     while url:
-        page = cache.get(url, headers=headers, proxies=proxies)
+        page = cache.get(url, headers=headers)
         for record in page['results']:
             pub = record['publication']
             doi = pub['ids'].get('doi')
@@ -362,10 +361,22 @@ def update_from_web(ctx, cache):  # noqa: C901
             )
 
     def reviews(ctx):
-        n_reviews = cache.get(
-            WOS_ACADEMIC_URL,
-            headers={'authorization': f'Token {os.environ["PUBLONS_TOKEN"]}'},
-        )['reviews']['pre']['count']
+        try:
+            n_reviews = cache.get(
+                WOS_ACADEMIC_URL,
+                headers={'authorization': f'Token {os.environ["PUBLONS_TOKEN"]}'},
+            )['reviews']['pre']['count']
+        except requests.exceptions.HTTPError as e:
+            # Publons/WoS rate-limits with HTTP 429; don't let a transient block
+            # fail the whole fetch (fetch_wos degrades the same way). Fall back
+            # to the last published review count so NUMREV still renders; skip
+            # the replacement entirely only if there's no prior value to reuse.
+            if not e.args[0].startswith('429'):
+                raise
+            logging.warning('Could not fetch Web of Science reviews: %r', e)
+            n_reviews = published_n_reviews()
+            if n_reviews is None:
+                return
         ctx['_n_reviews'] = n_reviews
         activity = ctx['activity']
         for i in range(len(activity)):

--- a/fetch.py
+++ b/fetch.py
@@ -312,10 +312,18 @@ def fetch_wos(cache):
     so DOI-less records can still be named.
     """
     headers = {'authorization': f'Token {os.environ["PUBLONS_TOKEN"]}'}
-    url = cache.get(WOS_ACADEMIC_URL, headers=headers)['publications']['url']
+    # Route through the same residential proxy as Google Scholar when
+    # configured; Publons/WoS also blocks datacenter/CI IPs. SCHOLAR_PROXY is
+    # a full proxy URL, e.g. http://user:pass@gw.dataimpulse.com:823.
+    proxies = None
+    if proxy := os.environ.get('SCHOLAR_PROXY'):
+        proxies = {'http': proxy, 'https': proxy}
+    url = cache.get(WOS_ACADEMIC_URL, headers=headers, proxies=proxies)[
+        'publications'
+    ]['url']
     works = []
     while url:
-        page = cache.get(url, headers=headers)
+        page = cache.get(url, headers=headers, proxies=proxies)
         for record in page['results']:
             pub = record['publication']
             doi = pub['ids'].get('doi')


### PR DESCRIPTION
## What

When the Publons/WoS API rate-limits with HTTP 429, skip the review-count fetch instead of failing the whole `make fetch`.

## Why

`fetch_wos` already tolerates a WoS failure (it warns and degrades to an empty list), but the separate `reviews()` call hits the same Publons API and let its 429 propagate, which set `has_errors` and failed the fetch job — as seen on this PR's first CI run (`429 Too Many Requests` from `publons.com/.../academic/...`).

## How

- `reviews()` now catches an HTTP 429 from the WoS API, logs a warning (mirroring `fetch_wos`), and falls back to the last published review count via the new `published_n_reviews()` helper, so `NUMREV` still renders. It only skips the replacement when there's no prior value to reuse. Non-429 HTTP errors still propagate.
- Reverted the earlier proxy-routing approach.

The integrity check (`check_derived.py`) already treats a missing count as a transient gap rather than a decrease, so a skipped fetch won't wrongly fail a publish.

https://claude.ai/code/session_01S17cLak74FjCQ3fFjfCpkL