### PR TITLE
Skip WoS cross-check when the source is unavailable

### DIFF
--- a/check_sources.py
+++ b/check_sources.py
@@ -234,7 +234,10 @@ def check_wos(refs, wos):
     """
     problems = []
     if not wos:
-        problems.append('no Web of Science works to cross-check against')
+        # Publons/WoS rate-limits with HTTP 429, leaving fetch.py with an empty
+        # list. Skip the WoS cross-check when the source is missing -- as the
+        # Scholar check does on a soft block -- rather than failing the deploy on
+        # a transient outage. A genuine partial regression still surfaces below.
         return problems
     wos_ids = {w['id'] for w in wos if w['id']}
     # Every Zotero paper WoS is expected to index must be present.


### PR DESCRIPTION
## What

Make the publication-sources cross-check skip Web of Science when no WoS data was fetched, instead of treating an empty list as a hard disagreement.

## Why

After #39, the WoS fetch tolerates a Publons `429 Too Many Requests` and degrades to an empty list. But on the push-to-main run the **cross-check** then failed:

```
publication sources disagree:
  - no Web of Science works to cross-check against
```

`check_wos` flagged the empty list as a regression, aborting before deploy on what is really a transient upstream rate-limit. This contradicts the function's own docstring (`empty = skipped`) and the Scholar check right above it, which already *skips* when its source is missing due to a soft block.

## How

`check_wos` now returns no problems when `wos` is empty (transient outage), while still flagging a genuine partial regression when WoS data *is* present. Verified locally:

- empty WoS → no problems (skipped)
- a missing/extra paper with WoS present → still flagged

No change to the ORCID handling, which intentionally still treats a missing source as a failure.

https://claude.ai/code/session_01S17cLak74FjCQ3fFjfCpkL

---
_Generated by [Claude Code](https://claude.ai/code/session_01S17cLak74FjCQ3fFjfCpkL)_