### PR TITLE
Add Bridgy Fed ownership-verification rel=me link

### DIFF
--- a/templates/index.html.in
+++ b/templates/index.html.in
@@ -76,6 +76,8 @@
   <div class="h-card">
 
   <h1 class="p-name"><a rel="me" class="u-url" href="https://jan.hermann.name"><span id="firstname">Jan</span> Hermann</a></h1>
+  {# Verifies ownership of the Bridgy Fed (fed.brid.gy) bridged account. #}
+  <a rel="me" href="https://web.brid.gy/jan.hermann.name" hidden></a>
   
   <section>  
     <p class="p-note">{{ bio }}


### PR DESCRIPTION
## What

Adds an invisible `rel="me"` link in the home-page h-card pointing to the Bridgy Fed bridged account:

```html
<a rel="me" href="https://web.brid.gy/jan.hermann.name" hidden></a>
```

## Why

[Bridgy Fed](https://fed.brid.gy/web/jan.hermann.name) auto-detected the site and created a bridged fediverse/Bluesky presence, but it can't confirm ownership without a bidirectional `rel=me` link. Combined with the existing `rel=me` on the canonical URL, this link lets Bridgy Fed verify the account (the "verified link" checkmark on Mastodon) after clicking **update profile** on the dashboard.

No effect on the Bluesky bridge, which is opt-in and remains inactive unless explicitly enabled.

## Verification

`make _site/index.html` renders the link into the output as expected.

https://claude.ai/code/session_01AGk9As8iQVqcQ25vkqFQwU

---
_Generated by [Claude Code](https://claude.ai/code/session_01AGk9As8iQVqcQ25vkqFQwU)_