### PR TITLE
Add rel=me matching Bridgy Fed actor url for Mastodon verification

### DIFF
--- a/templates/index.html.in
+++ b/templates/index.html.in
@@ -78,6 +78,10 @@
   <h1 class="p-name"><a rel="me" class="u-url" href="https://jan.hermann.name"><span id="firstname">Jan</span> Hermann</a></h1>
   {# Verifies ownership of the Bridgy Fed (fed.brid.gy) bridged account. #}
   <a rel="me" href="https://web.brid.gy/jan.hermann.name" hidden></a>
+  {# Mastodon verifies a remote account's profile links against its `url` field,
+     which Bridgy Fed serves in this redirect form (not the actor id above), so
+     this rel=me is what earns the green "verified link" badge. #}
+  <a rel="me" href="http://web.brid.gy/r/https://jan.hermann.name/" hidden></a>
   {# Transparent u-featured so the bridged Mastodon profile uses a blank header
      instead of falling back to the avatar (u-photo) for its banner. #}
   <img class="u-featured" src="header-blank.png" alt="" hidden>


### PR DESCRIPTION
## What

Adds a second hidden `rel="me"` link on the home page whose href exactly matches the bridged actor's `url` field:

```html
<a rel="me" href="http://web.brid.gy/r/https://jan.hermann.name/" hidden></a>
```

## Why

The Mastodon "verified link" badge wasn't appearing despite the existing `rel=me` → `https://web.brid.gy/jan.hermann.name` (the actor **id**, which Bridgy Fed's docs recommend).

Root cause: Mastodon's `VerifyLinkService` compares a **remote** account's profile-field links against `ActivityPub::TagManager#url_for(account)`, which for remote accounts returns the account's **`url`** attribute — not its `uri`/`id`. Bridgy Fed serves that `url` as a redirect form:

```
url: http://web.brid.gy/r/https://jan.hermann.name/
```

So the page's `rel=me` (pointing at the id) never matched what Mastodon checks against, and the id URL `302`s to the site rather than to the `url` form, so the redirect-fallback didn't bridge them either.

Adding a `rel=me` that matches the served `url` exactly makes Mastodon's direct comparison succeed. The original id `rel=me` is kept (Bridgy Fed uses it for its own ownership check).

## Notes

- The `http://` scheme and trailing slash must match Bridgy Fed's `url` exactly; if Bridgy changes that format the link would need updating. The `http://` in a hyperlink is harmless (no subresource load, so no mixed-content).
- Badge is cosmetic; the rest of the bridge already works.

## Verification

`make _site/index.html` renders both `brid.gy` `rel=me` links with exact strings preserved (no URL normalization by the build).

https://claude.ai/code/session_01AGk9As8iQVqcQ25vkqFQwU

---
_Generated by [Claude Code](https://claude.ai/code/session_01AGk9As8iQVqcQ25vkqFQwU)_