### PR TITLE
Move superscript citations after sentence punctuation

### DIFF
--- a/render.py
+++ b/render.py
@@ -305,6 +305,23 @@ def cited_keys(md_text):
     return list(dict.fromkeys(keys))
 
 
+def move_citations_after_punctuation(html):
+    """Pandoc drops the superscript citation exactly where its [@key] sits in the
+    prose, so a citation written before a sentence's period renders before it
+    (`...cost<sup>1</sup>.`). House style puts the marker after the punctuation;
+    swap any citation span that directly precedes a run of clause/sentence
+    punctuation so it follows it instead (`...cost.<sup>1</sup>`). The space the
+    prose puts before the citation (`cost [@key].`) is dropped so the punctuation
+    binds tight to the word (`cost.`) rather than floating (`cost .`). A citation
+    closing a parenthetical (`...field<sup>23</sup>).`) is left inside the
+    parentheses, since `)` is not in the punctuation set."""
+    return re.sub(
+        r'\s*(<span class="citation"[^>]*>.*?</span>)([.,;:!?]+)',
+        r'\2\1',
+        html,
+    )
+
+
 def render_hub_sections(ctx):
     """Render the homepage sections from data/hubs.md. The whole file (all
     sections) goes through pandoc + citeproc in one pass so citation numbers run
@@ -324,7 +341,7 @@ def render_hub_sections(ctx):
     order = re.findall(r'id="ref-([^"]+)"', refs.group(0)) if refs else []
     ctx['cite_num'] = {key: i + 1 for i, key in enumerate(order)}
     by_number = lambda k: ctx['cite_num'].get(k, len(order) + 1)
-    prose = html[: refs.start()] if refs else html
+    prose = move_citations_after_punctuation(html[: refs.start()] if refs else html)
 
     # Split into (header, body) per <h1>; read structure from header attributes
     # and the section's references from the citations its body carries.


### PR DESCRIPTION
Stacks on #51.

Pandoc renders each `[@key]` exactly where it sits in the hub prose, so a citation written before a period rendered **before** it (`…cost¹.`). House style puts the marker after the punctuation, so this post-processes the rendered prose in `render.py` to swap any citation span that directly precedes clause/sentence punctuation (`. , ; : ! ?`) so the marker follows it instead (`…cost.¹`).

Details:
- The space the prose puts before a citation (`cost [@key].`) is dropped so the punctuation binds tight to the word (`cost.`) rather than floating (`cost .`); the space after the punctuation is preserved.
- A citation closing a parenthetical (`…field²³).`) is left inside the parentheses, since `)` isn't in the punctuation set.
- Grouped citations (`[@a; @b]` → `¹,²`) move as a unit.

`data-cites` extraction and the discarded bibliography are unaffected — only the displayed prose is rewritten.

---
_Generated by [Claude Code](https://claude.ai/code/session_0135hKCCxbXTp5jMRTQN9mUW)_