### PR TITLE
devcontainer: add venv PATH and GITHUB_REPOSITORY env vars

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -14,6 +14,10 @@
             ]
         }
     },
-    "onCreateCommand": "wget -nv -O - $FONTS_URL | tar -xzv",
+    "remoteEnv": {
+        "PATH": "${containerWorkspaceFolder}/.venv/bin:${containerEnv:PATH}",
+        "GITHUB_REPOSITORY": "jhrmnn/jhrmnn.github.io"
+    },
+    "onCreateCommand": "poetry config virtualenvs.in-project true && wget -nv -O - $FONTS_URL | tar -xzv",
     "updateContentCommand": "poetry install --with dev"
 }


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Configure Poetry to use an in-project `.venv` (via `poetry config virtualenvs.in-project true` in `onCreateCommand`) so the venv bin dir is at a predictable path
- Add `remoteEnv` with `.venv/bin` prepended to `PATH`, fixing `make` targets whose scripts use `#!/usr/bin/env python3` resolving to the bare system Python instead of the project venv
- Add `GITHUB_REPOSITORY` to `remoteEnv` as a fallback for local devcontainer use (Codespaces injects it automatically)

## Test plan

- [ ] Open repo in a Codespace or local devcontainer and verify `which python3` resolves to `.venv/bin/python3`
- [ ] Run `make fetch` and confirm it finds `bs4`/`nltk`/`iso4` without errors
- [ ] Verify `echo $GITHUB_REPOSITORY` prints `jhrmnn/jhrmnn.github.io` in a local devcontainer session

https://claude.ai/code/session_01UEXtE9ByusVD17C2MesVoP
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UEXtE9ByusVD17C2MesVoP)_