### PR TITLE
Install git in the render image so post timestamps work

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@ FROM ubuntu:24.04
 RUN --mount=type=cache,target=/var/lib/apt/lists apt-get update && \
     DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt-get install -y --no-install-recommends \
         entr \
+        git \
         make \
         latexmk \
         pandoc \

--- a/posts.py
+++ b/posts.py
@@ -70,18 +70,31 @@ def git_dates(path):
     an ActivityPub Update, so a post that's been edited after publication
     actually changes on Mastodon. Without it the re-sent webmention refers to
     an object that looks unchanged and the edit never surfaces. Needs full
-    history at render time (CI checks out with fetch-depth: 0)."""
+    history at render time (CI checks out with fetch-depth: 0) and git present
+    in the render image — without git, checkout falls back to a REST tarball
+    with no .git and every post would silently lose its timestamps.
+
+    `safe.directory=*` defuses git's dubious-ownership guard, which otherwise
+    aborts when the checkout is owned by a different user than the render
+    process (common in containers)."""
     try:
-        out = subprocess.run(
-            ['git', 'log', '--format=%aI', '--', str(path)],
+        proc = subprocess.run(
+            ['git', '-c', 'safe.directory=*', 'log', '--format=%aI', '--', str(path)],
             capture_output=True,
             text=True,
-            check=True,
-        ).stdout.split()
-    except (subprocess.CalledProcessError, FileNotFoundError):
+        )
+    except FileNotFoundError:
+        # git missing entirely (e.g. not installed in the render image): this is
+        # a real misconfiguration, not an untracked post, so make it loud.
+        print(f'warning: git not found; {path} loses its timestamps', file=sys.stderr)
         return None, None
+    if proc.returncode != 0:
+        # Not a git repo (e.g. REST-tarball checkout) or another git error.
+        print(f'warning: git log failed for {path}: {proc.stderr.strip()}', file=sys.stderr)
+        return None, None
+    out = proc.stdout.split()
     if not out:
-        return None, None
+        return None, None  # tracked repo but file not committed yet (local dev)
     return out[-1], out[0]  # git log is newest-first: oldest, newest
 
 


### PR DESCRIPTION
## Why

PR #56 made `posts.py` derive `dt-published`/`dt-updated` from `git log`, and it works locally — but in production it produces nothing. The `render` job runs inside the project's Docker image, and **that image has no `git`**. When `actions/checkout` runs in a container without git, it falls back to downloading a REST tarball with **no `.git` directory**, so `git_dates()` hits its caught exception, returns `(None, None)`, and every post silently reverts to the filename date with no `dt-updated`.

Confirmed against the live site after #56 deployed: both `notes/2026-06-15-llm-skeptic/` and `notes/2024-12-30-good-evil/` still render the old date-only `<time class="dt-published" datetime="2026-06-15">` — the git-derived timestamps never appear.

## Fix

- **`Dockerfile`**: install `git`, so the render-job checkout does a real clone (with `.git` and full history under `fetch-depth: 0`).
- **`posts.py` / `git_dates`**: pass `-c safe.directory=*` to defuse git's dubious-ownership guard in containers, and print a stderr warning when git is missing or `git log` errors — so a regression like this is loud instead of silently dropping every post's timestamps. An uncommitted post (empty log, exit 0) stays silent, as before.

## After merge

This needs to deploy before the live pages carry `dt-updated`. Once it's live I'll send a webmention for the existing `llm-skeptic` post so Bridgy Fed re-fetches and federates the edit as an ActivityPub `Update` (the merge won't auto-federate it, since it changes no `posts/*.md`).

https://claude.ai/code/session_01LuHFtfv1xt4mUwsieayDuN

---
_Generated by [Claude Code](https://claude.ai/code/session_01LuHFtfv1xt4mUwsieayDuN)_