### PR TITLE
Hide the "updated" badge for same-day edits

### DIFF
--- a/templates/post.html.in
+++ b/templates/post.html.in
@@ -15,7 +15,15 @@
     {% if post.title %}<h1 class="p-name">{{ post.title }}</h1>{% endif %}
     <p class="postmeta">
       <a class="u-url" href="{{ post.url }}"><time class="dt-published" datetime="{{ post.datetime }}">{{ post.date_display }}</time></a>
-      {%- if post.updated %} &middot; <time class="dt-updated" datetime="{{ post.updated }}">updated {{ post.updated_display }}</time>{% endif %}
+      {#- Keep dt-updated in the markup whenever the post was edited (Bridgy Fed
+          needs it to federate the edit as an Update), but only show the visible
+          "updated …" badge when it falls on a different day than publication —
+          a same-day edit next to the publish date is just noise. #}
+      {%- if post.updated %}
+        {%- if post.updated_display != post.date_display %} &middot; <time class="dt-updated" datetime="{{ post.updated }}">updated {{ post.updated_display }}</time>
+        {%- else %} <time class="dt-updated" datetime="{{ post.updated }}" hidden></time>
+        {%- endif %}
+      {%- endif %}
       &middot; by <a class="p-author h-card u-author" href="/">Jan Hermann</a>
     </p>
     <div class="e-content">


### PR DESCRIPTION
## Why

A post edited on its publication day rendered a visible "updated 15 June 2026" badge right next to the publish date "15 June 2026" — redundant noise. (This very post, `llm-skeptic`, is the case.)

## Change

`templates/post.html.in`: only render the visible "updated …" badge when the edit falls on a **different day** than publication.

Crucially, the machine-readable `<time class="dt-updated" datetime="…">` stays in the markup either way — `hidden` when the days coincide — so Bridgy Fed still federates same-day edits as ActivityPub `Update`s. Dropping it would have re-broken the very thing PRs #56/#57 fixed.

A later-day edit still shows the badge as before.

### Verified locally
Same-day edit (`llm-skeptic`) now renders:
```html
<time class="dt-published" datetime="2026-06-15T16:40:58+02:00">15 June 2026</time>
<time class="dt-updated" datetime="2026-06-15T16:43:37+02:00" hidden></time>
```
Visible text: "15 June 2026 · by Jan Hermann" — no redundant badge, `dt-updated` still present for federation.

https://claude.ai/code/session_01LuHFtfv1xt4mUwsieayDuN

---
_Generated by [Claude Code](https://claude.ai/code/session_01LuHFtfv1xt4mUwsieayDuN)_