### PR TITLE
Restore Mastodon verified badge: match Bridgy Fed actor url scheme (https)

### DIFF
--- a/templates/index.html.in
+++ b/templates/index.html.in
@@ -122,8 +122,9 @@
   <a rel="me" href="https://web.brid.gy/jan.hermann.name" hidden></a>
   {# Mastodon verifies a remote account's profile links against its `url` field,
      which Bridgy Fed serves in this redirect form (not the actor id above), so
-     this rel=me is what earns the green "verified link" badge. #}
-  <a rel="me" href="http://web.brid.gy/r/https://jan.hermann.name/" hidden></a>
+     this rel=me is what earns the green "verified link" badge. The scheme must
+     match exactly: Bridgy Fed now serves the url over https (it used to be http). #}
+  <a rel="me" href="https://web.brid.gy/r/https://jan.hermann.name/" hidden></a>
   {# Transparent u-featured so the bridged Mastodon profile uses a blank header
      instead of falling back to the avatar (u-photo) for its banner. #}
   <img class="u-featured" src="header-blank.png" alt="" hidden>


### PR DESCRIPTION
## Problem

The bridged Mastodon account (`@jan.hermann.name@web.brid.gy`) lost its green "verified link" badge.

## Cause

Mastodon awards the verified badge when it fetches the homepage and finds a `rel="me"` link whose href **exactly matches the bridged actor's `url` field** (scheme included). The live Bridgy Fed actor JSON now reports:

```json
"url": "https://web.brid.gy/r/https://jan.hermann.name/"
```

But the homepage verification link (added in #44) still used `http://`:

```html
<a rel="me" href="http://web.brid.gy/r/https://jan.hermann.name/" hidden></a>
```

When #44 landed, Bridgy Fed served that `url` over `http`. Bridgy Fed has since switched it to `https`, so the scheme no longer matches and verification fails.

## Fix

Change the verification `rel="me"` link from `http://` to `https://` so it matches the actor's current `url`, and note in the comment that the scheme must match exactly.

https://claude.ai/code/session_01RWqDMDVvLYtbQHuJpHBXz7

---
_Generated by [Claude Code](https://claude.ai/code/session_01RWqDMDVvLYtbQHuJpHBXz7)_