### PR TITLE
Add Weather link to navigation

### DIFF
--- a/templates/index.html.in
+++ b/templates/index.html.in
@@ -110,6 +110,7 @@
     <li><a href="#Works">Works</a> ({% for sec in sections if not sec.theme %}{% if not loop.first %} &middot; {% endif %}<a href="#{{ sec.id }}">{{ sec.nav }}</a>{% endfor %})
     <li><a href="#CV">CV</a> (as <a href="cv.pdf">{% include "assets/file-pdf-solid.svg" %}</a>)
     <li><a href="/notes/">Notes</a>
+    <li><a href="/weather/">Weather</a>
   </ul>
 </nav>
 


### PR DESCRIPTION
Adds a **Weather** link to the homepage navigation, pointing to `/weather/` (https://jan.hermann.name/weather/), alongside the existing Notes link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017AV4Wu5ztptFrsZDQNP5eQ

---
_Generated by [Claude Code](https://claude.ai/code/session_017AV4Wu5ztptFrsZDQNP5eQ)_