### PR TITLE
Update FHI-aims roadmap citation from arXiv preprint to published version

### DIFF
--- a/data/extras.yaml
+++ b/data/extras.yaml
@@ -2,7 +2,7 @@
 # (<Surname><JournalInitials><YY>, derived in fetch.py and used as the reference
 # id). The trailing comment is the canonical DOI/handle and the title.
 ref_extras:
-  Abbott25:  # 10.48550/arxiv.2505.00125 — Roadmap on Advancements of the FHI-aims Software Package
+  AbbottES26:  # 10.1088/2516-1075/ae8067 — Roadmap on Advancements of the FHI-aims Software Package
     PDF: https://nablapsi.science/2505.00125v1.pdf
   ChengJCP25:  # 10.1063/5.0236919 — Highly accurate real-space electron densities with neural ne
     PDF: https://nablapsi.science/2409.01306v1.pdf

--- a/data/hubs.md
+++ b/data/hubs.md
@@ -55,7 +55,7 @@ fluctuational-electrodynamics phenomena [@VenkataramPRL17; @VenkataramPRL18;
 
 No tool stands alone. libMBD is built into FHI-aims, DFTB+, and other
 electronic-structure codes; Pyberny into PySCF and QCEngine — integrations
-reflected in their program papers [@Abbott25; @HourahineJCP20; @SunJCP20;
+reflected in their program papers [@AbbottES26; @HourahineJCP20; @SunJCP20;
 @SmithJCP21]. The same connective work runs through survey writing across the
 field, from a roadmap on machine learning in electronic structure [@KulikES22] to
 an introduction to material modeling [@Hermann20], alongside the invited seminars


### PR DESCRIPTION
## What

The FHI-aims roadmap preprint was promoted to its published version, which changed its derived citation key. Update the two hand-maintained references to the paper so `make` (render's homepage completeness check) passes again.

- `data/hubs.md`: `@Abbott25` → `@AbbottES26`
- `data/extras.yaml`: `Abbott25:` → `AbbottES26:`, and the trailing DOI comment `10.48550/arxiv.2505.00125` → `10.1088/2516-1075/ae8067`

## Why

Updating the Zotero item from the arXiv preprint (`10.48550/arxiv.2505.00125`) to the published article in *Electronic Structure* (`10.1088/2516-1075/ae8067`, 2026-06-22) changes the reference's derived citation key from `Abbott25` to `AbbottES26`: the published version has a journal short title ("Electron. Struct." → `ES` initials) and a 2026 issue date, both of which feed `citation_key` in `fetch.py`.

Two consequences appeared in CI, in order:

1. `check_derived.py` flagged `reference removed: 10.48550/arxiv.2505.00125` (the canonical DOI join key changed). That's the guard's intended behavior for a legitimate preprint→published transition and was cleared via the built-in `workflow_dispatch` override (the check is `continue-on-error` on manual dispatch).
2. With the new data published, `render.py`'s homepage completeness check then failed:

   ```
   - publications cited nowhere (cite them in data/hubs.md): AbbottES26
   - references absent from fetched data: Abbott25
   ```

   because `data/hubs.md` and `data/extras.yaml` still keyed the paper as `Abbott25`. This PR fixes that.

The `extras.yaml` PDF override is left pointing at the arXiv PDF, which still serves the paper's content.

## Testing

Rendered the homepage locally against the freshly fetched `derived.json` (the artifact from the dispatch run that published the new data): `render.py templates/index.html.in … --derived build/derived.json` now exits 0, so the completeness check passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012ZTMCh78o7uiXbCkVNi8To)_