### PR TITLE
Make the Google Scholar fetch robust to empty and merged-count profiles

### DIFF
--- a/fetch.py
+++ b/fetch.py
@@ -455,6 +455,18 @@ def fetch_scholar(cache):
                     raise requests.exceptions.RequestException(
                         'Scholar served a CAPTCHA/block page (HTTP 200 soft block)'
                     )
+                # A proxy/error page or an unrecognised block variant can return
+                # HTTP 200 with a body that carries no publication rows. Parsing
+                # that yields an empty profile, and an empty scholar_cites is
+                # silently skipped downstream (see update_from_web) -- so the job
+                # would still succeed and publish a citation-less artifact,
+                # wiping every count from the site. Treat "no rows" like a block:
+                # retry on a fresh exit IP, and if it never clears, raise rather
+                # than publishing empty counts.
+                if not parse_scholar_profile_html(r.text):
+                    raise requests.exceptions.RequestException(
+                        'Scholar profile parsed to zero publication rows'
+                    )
             except requests.exceptions.RequestException as e:
                 if attempt < attempts - 1:
                     logging.info('Scholar fetch attempt %d failed: %r', attempt + 1, e)

--- a/fetch.py
+++ b/fetch.py
@@ -148,7 +148,11 @@ def _scholar_rows(html):
     soup = BeautifulSoup(html, "html.parser")
     for row in soup.select("#gsc_a_t .gsc_a_tr"):
         title = row.select_one(".gsc_a_at").get_text(strip=True)
-        cites = int(row.select_one(".gsc_a_c").get_text(strip=True) or 0)
+        # Scholar renders the count as plain digits, but marks a merged entry's
+        # count with a trailing "*" (the total spans the merged versions) and
+        # groups large counts with commas ("1,234"). Keep only the digits so
+        # neither form crashes int(); an empty cell (no citations) folds to 0.
+        cites = int(re.sub(r'\D', '', row.select_one(".gsc_a_c").get_text(strip=True)) or 0)
         year_cell = row.select_one(".gsc_a_y")
         year = year_cell.get_text(strip=True) if year_cell else ''
         # The second grey line is the venue, e.g. "J. Chem. Inf. Model. 65 (18),


### PR DESCRIPTION
## What

Two fixes to `fetch.py`'s Google Scholar parsing, both surfaced by the FHI-aims roadmap paper going from preprint to published and its two Scholar versions being merged:

1. **Parse the merged-count asterisk (and comma grouping).** `_scholar_rows` fed the citation-count cell straight to `int()`. Scholar marks a *merged* entry's count with a trailing `*` (the total spans the merged versions) and groups large counts with commas (`1,234`), so after the two versions were merged the count came back as `23*` and `int()` raised `ValueError`. That isn't a `RequestException`, so `collect()` didn't absorb it — it crashed the whole fetch. Now non-digits are stripped before `int()`, and an empty cell still folds to 0.

2. **Fail on a zero-row Scholar parse.** After the existing `/sorry/` + "unusual traffic" soft-block check, `fetch_scholar` now raises when the profile parses to zero publication rows, so the run retries on a fresh proxy IP and, if it never clears, fails before the artifact upload.

## Why

The live site lost **all** citation numbers, via two distinct Scholar states across two runs:

- A `main` fetch got a 200 response that parsed to **zero rows** (a proxy/error page or an unrecognised block variant). `scholar_cites` was an empty dict, and the count-application step is guarded by `if ctx.get("scholar_cites"):` — an empty dict is falsy, so it was silently skipped. Nothing raised, the job stayed green, and the citation-less artifact deployed. Since render always uses the newest artifact, every number vanished. → **fix 2**
- A re-fetch then got the profile **with** the merged asterisk count `23*`, which crashed the fetch outright. → **fix 1**

Both integrity checks pass through absent Scholar data as a transient gap (`check_derived.py` compares Scholar only `if new_sc:` and treats a `cited_by` going missing as a gap, not a decrease; `check_sources.py` guards its coverage loop with `if scholar:`), so neither could catch the empty case — and the asterisk case died before any check ran.

## Testing

- `python -m py_compile fetch.py` passes.
- `parse_scholar_profile_html` on synthetic rows: `23*` → 23, `1,234` → 1234, `42` → 42, empty cell → 0, and a page with no profile rows → `{}` (which now triggers the zero-row raise).

## Restoring the live numbers

This is the durable fix; the live counts come back on the first fetch **after** this merges (the daily 05:00 schedule, or a manual dispatch). A dispatch before merging just re-hits the asterisk crash, since `main` doesn't yet carry these changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)