### PR TITLE
Opt out of Bridgy Fed with #nobridge

### DIFF
--- a/templates/index.html.in
+++ b/templates/index.html.in
@@ -130,8 +130,13 @@
      instead of falling back to the avatar (u-photo) for its banner. #}
   <img class="u-featured" src="header-blank.png" alt="" hidden>
 
-  <section>  
-    <p class="p-note">{{ bio }}
+  <section>
+    {# Opt out of the Bridgy Fed bridge (fed.brid.gy): the literal `#nobridge`
+       in the h-card note tells fed.brid.gy not to bridge this site into the
+       fediverse (federating directly instead). `hidden` keeps it out of the
+       rendered bio while leaving it in the parsed p-note that fed.brid.gy reads
+       — the same reason the rel=me links above use `hidden`. #}
+    <p class="p-note">{{ bio }}<span hidden> #nobridge</span>
     
     <p id="profile-pic"><img class="u-photo" src="profile-pic-web.jpeg" alt="Jan Hermann" width="160" height="160">
     


### PR DESCRIPTION
## What this does

Adds a hidden `#nobridge` flag to the home-page h-card note so [fed.brid.gy](https://fed.brid.gy) stops bridging the site into the fediverse — the plan is to federate directly instead of via the bridge.

## How it works

Bridgy Fed reads the opt-out flag from the h-card **note** (the `p-note`). The change appends `#nobridge` inside that element but wrapped in a `hidden` span:

```html
<p class="p-note">{{ bio }}<span hidden> #nobridge</span>
```

- `hidden` keeps it out of the rendered bio, but microformats2 parses the HTML source (not the rendered page), so the flag still appears in the `p-note` that Bridgy reads — the same trick the existing `rel="me"` links already use.
- Verified with a standalone Jinja render: the `{# #}` comment is stripped and the hidden `#nobridge` span lands in the `p-note`. (The full `make` build fails locally only on the unrelated data-completeness guard, which runs before template rendering and passes in CI with freshly fetched data.)

## Follow-up (outside the repo)

For the opt-out to take effect on Bridgy's side after this deploys, trigger a profile refresh at `https://fed.brid.gy/web/hrmnn.net` (the **Update profile** button, or POST to `/web/hrmnn.net/update-profile`) so it re-reads the page and sees `#nobridge`.

The bridge-specific `rel="me"` links to `web.brid.gy` and the `federate` webmention job are left in place — inert while opted out, and easy to remove later if the direct-federation plan is confirmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01YTj4gu7nqmuZx24jiFXEQA)_