### PR TITLE
Promote a leading level-1 heading to the post title

### DIFF
--- a/posts.py
+++ b/posts.py
@@ -62,6 +62,28 @@ def md_blocks_to_html(text):
     return '\n'.join(out)
 
 
+def extract_leading_title(body):
+    """When a post carries no explicit `title` metadata, promote a leading
+    level-1 Markdown heading (`# ...`) to the post title and strip it from the
+    body, so a note can name itself inline instead of in front matter. Only a
+    single leading `#` qualifies (a level-1 heading); `##`+ are section headings
+    and stay in the body. Returns (title, body) with the heading removed, or
+    (None, body) unchanged when the first content isn't a level-1 heading."""
+    lines = body.split('\n')
+    i = 0
+    while i < len(lines) and not lines[i].strip():
+        i += 1  # skip any blank lines before the first content
+    if i == len(lines):
+        return None, body
+    first = lines[i].strip()
+    if not first.startswith('#') or first.startswith('##'):
+        return None, body
+    title = first.lstrip('#').strip()
+    if not title:
+        return None, body
+    return title, '\n'.join(lines[i + 1:])
+
+
 def git_dates(path):
     """First and last git author dates touching `path`, as ISO-8601 strings,
     or (None, None) if the file isn't tracked yet (e.g. a brand-new post in
@@ -118,6 +140,11 @@ def parse_post(path):
     first_commit, last_commit = git_dates(path)
     published = first_commit or date.strftime('%Y-%m-%d')
     updated = last_commit if first_commit and last_commit != first_commit else None
+    # An explicit `title:` in front matter wins; otherwise a leading level-1
+    # heading in the body is promoted to the title (and dropped from the body).
+    title = meta.get('title')
+    if title is None:
+        title, body = extract_leading_title(body)
     return {
         'segment': segment,
         # Relative permalink for in-page links and u-url, so navigation works on
@@ -127,8 +154,9 @@ def parse_post(path):
         'canonical': f'{BASE_URL}/notes/{segment}/',
         # Optional: a post with a title is an article, one without is a note (a
         # short, status-style post). The templates omit p-name when absent so
-        # microformats2 parsers treat it as a note.
-        'title': meta.get('title'),
+        # microformats2 parsers treat it as a note. Sourced from `title:` front
+        # matter or a leading level-1 heading (see above).
+        'title': title,
         # dt-published timestamp (full ISO-8601 from git); the display string and
         # the sort key stay on the filename date, which is the canonical day and
         # already lives in the permalink.

--- a/posts/2026-07-12-two-translations.md
+++ b/posts/2026-07-12-two-translations.md
@@ -1,0 +1,11 @@
+# The Two Translations
+
+An artist begins with an Idea, a schematic approximation of a Form that is perfect and fully determined. The Idea is then rendered as an Instance, the work itself, which is also an approximation of the Form: fully determined now, but imperfect and distorted. An approximation of an approximation.
+
+Form and Instance are both fully determined, but for opposite reasons. The Form is complete because nothing in it could be otherwise; the Instance because everything in it had to be decided—this pigment, this interval, this word. The Idea alone is determined unevenly, fixed where it matters and open elsewhere. Each thing it leaves open is one thing it cannot get wrong, so the schematic Idea is more faithful than the Instance.
+
+When a beholder arrives, the work becomes communication: the artist's Idea, sent through the Instance. Picture a diamond ⟠, the Form at the top, the artist's Idea and the beholder's Idea at the side corners, the Instance at the bottom. The artist comes down one side; the beholder climbs the other, reading an Idea back out of the Instance. If that were the beholder's only source, the recovered Idea could be no more faithful than the Instance. But the Form is universal, sensed by every person. Reaching it directly, the beholder can correct the recovered Idea, which may then sit truer to the Form than the artist's own.
+
+The beholder can then judge the work twice. The Instance is measured against the recovered Idea: does the making do justice to the conception? This is the obvious judgment, where craft shows. The Idea is measured against the Form: is the conception faithful to its original? This is the deeper one, and the harder art is to find Ideas that are both worth the looking and able to survive being made. What is judged is not faithfulness to the artist but faithfulness to the Form.
+
+So the work is seen twofold: at once a flawed Instance and a Form made visible. It is less a container for the Idea than a way of drawing attention to the Form behind it.


### PR DESCRIPTION
## What

Change note parsing so that when a post has no explicit `title:` in front matter, a leading level-1 Markdown heading (`# ...`) in the body is promoted to the post title and stripped from the body. This lets a note name itself inline, without needing a front-matter block.

## Why

Previously the title came *only* from `title:` front matter (`meta.get('title')`); a `#` heading at the top of a note was just rendered as an `<h2>` inside the body. Writing a titled article meant hand-authoring YAML front matter. Now the natural Markdown convention — a leading `#` heading — does the right thing.

## How

- New helper `extract_leading_title(body)` in `posts.py`: skips leading blank lines, and if the first content line is a single-`#` (level-1) heading, returns `(title, body_without_heading)`. `##`+ headings are left in place as section headings; a title-less note stays a note.
- `parse_post` now falls back to `extract_leading_title` when front-matter `title` is absent. Explicit `title:` front matter still wins.

## Verification

- Unit-checked the helper across leading `#`, leading blank lines, `##` (not promoted), no-heading, `#`-with-no-space, and empty-`#` cases.
- Full render of all posts: the new note renders with `<h1 class="p-name">`, correct `<title>`, a blog-index `<h2>` article entry, and no duplicate heading in the body; existing title-less notes still render without `p-name`.
- `flake8 posts.py` clean.

Also adds `posts/2026-07-12-two-translations.md`, which uses the new inline-title style.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R2DV6UYYHjBSVajxzUzh9F

---
_Generated by [Claude Code](https://claude.ai/code/session_01R2DV6UYYHjBSVajxzUzh9F)_