### PR TITLE
Tighten measure to ~75ch and harmonize leading to 1.5

### DIFF
--- a/templates/styles.css
+++ b/templates/styles.css
@@ -1,8 +1,15 @@
 body {
     padding: 0 5px 30px 5px;
     margin: 0 auto;
-    max-width: 45em;
+    /* ~75-character measure — the largest single-column line length still
+       regarded as comfortable (Bringhurst's 45–75 range; ~2 chars per em). */
+    max-width: 37.5em;
     font-family: sans-serif;
+    /* Leading paired to that measure at the smallest defensible value: 1.5 is
+       the WCAG 1.4.8 (AAA) minimum for blocks of text, and a line this wide
+       needs at least this much to track the return sweep. Unitless so it
+       scales per element; set here so spacing is uniform site-wide. */
+    line-height: 1.5;
     -webkit-text-size-adjust: 100%;
 }
 
@@ -56,8 +63,9 @@ dt::after {
    Strava, ...) in one column, tight enough that each link sits within 24px of
    the rows above and below, failing the target-size (WCAG 2.5.8) check. 1.5
    makes each row a 24px line box — the minimum that spaces the vertical centres
-   the required 24px apart; scoped to the whole <dl> so the floated <dt> labels
-   share the line box and stay aligned with their <dd> values. */
+   the required 24px apart. This matches the site-wide line-height, but is kept
+   explicit as a guard: unlike the prose, this row spacing is load-bearing for
+   target size and must not regress if the shared leading ever changes. */
 .h-card dl {
     line-height: 1.5;
 }
@@ -321,10 +329,6 @@ tr.heading:not(:first-child) td {
     color: #666;
     font-size: 0.9em;
     margin-top: -0.4em;
-}
-
-.e-content {
-    line-height: 1.5;
 }
 
 .h-feed article.h-entry {


### PR DESCRIPTION
## Summary

Applies two paired typographic rules to the site's line length and line spacing:

- **Largest defensible measure.** `body { max-width }` goes from `45em` (~90 characters) to **`37.5em` (~75 characters)** — the upper bound of Bringhurst's satisfactory single-column range (45–75), at the standard ~2 characters per `em` for a proportional sans-serif.
- **Smallest defensible leading for that measure.** Body `line-height` is set to **`1.5`** — the WCAG 1.4.8 (AAA) minimum for blocks of text, and the least a line that wide needs to reliably track the return sweep.

## Harmonization

Setting `line-height: 1.5` on `body` makes leading uniform site-wide (previously the homepage inherited the browser default ~1.2, while only `.e-content` prose and the social hub used 1.5).

- Removed the now-redundant `.e-content { line-height: 1.5 }` override — it inherits from `body`.
- Kept the explicit `1.5` on `.h-card dl`, whose row spacing is load-bearing for the target-size requirement (WCAG 2.5.8); a comment notes it now matches the shared value but is retained as a guard against future regressions.

The `.citation sup { line-height: 0 }` rule is untouched — it deliberately keeps superscripts from enlarging the line box.

## Notes

CSS-only change. The full site build fetches live publication data from a GitHub artifact (unrelated to this diff), so verification was done against the stylesheet directly: balanced braces/comments and confirmed there are no remaining prose line-heights below 1.5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MUtvCYjGybtzSZSD5K2sFT

---
_Generated by [Claude Code](https://claude.ai/code/session_01MUtvCYjGybtzSZSD5K2sFT)_